### PR TITLE
GPS passthrough cli command

### DIFF
--- a/src/cli.c
+++ b/src/cli.c
@@ -9,6 +9,7 @@ static void cliDefaults(char *cmdline);
 static void cliDump(char *cmdLine);
 static void cliExit(char *cmdline);
 static void cliFeature(char *cmdline);
+static void cliGpsPassthrough(char *cmdline);
 static void cliHelp(char *cmdline);
 static void cliMap(char *cmdline);
 static void cliMixer(char *cmdline);
@@ -73,6 +74,7 @@ const clicmd_t cmdTable[] = {
     { "dump", "print configurable settings in a pastable form", cliDump },
     { "exit", "", cliExit },
     { "feature", "list or -val or val", cliFeature },
+    { "gpspassthrough", "passthrough gps to serial", cliGpsPassthrough },
     { "help", "", cliHelp },
     { "map", "mapping of rc channel order", cliMap },
     { "mixer", "mixer name or list", cliMixer },
@@ -654,6 +656,15 @@ static void cliFeature(char *cmdline)
                 break;
             }
         }
+    }
+}
+
+static void cliGpsPassthrough(char *cmdline)
+{
+    cliPrint("Enabling GPS passthrough...");
+
+    if (gpsSetPassthrough() == -1) {
+        cliPrint("Error: Enable and plug in GPS first\r\n");
     }
 }
 

--- a/src/gps.c
+++ b/src/gps.c
@@ -521,6 +521,32 @@ void gpsSetPIDs(void)
     navPID_PARAM.Imax = POSHOLD_RATE_IMAX * 100;
 }
 
+int8_t gpsSetPassthrough(void)
+{
+    if (gpsData.state != GPS_RECEIVINGDATA)
+        return -1;
+
+// get rid of callback
+    core.gpsport->callback = NULL;
+
+    LED0_OFF;
+    LED1_OFF;
+
+    while(1) {
+        if (serialTotalBytesWaiting(core.gpsport)) {
+            LED0_ON;
+            serialWrite(core.mainport, serialRead(core.gpsport));
+            LED0_OFF;
+            }
+        if (serialTotalBytesWaiting(core.mainport)) {
+            LED1_ON;
+            serialWrite(core.gpsport, serialRead(core.mainport));
+            LED1_OFF;
+            }
+        }
+}
+
+
 // OK here is the onboard GPS code
 
 ////////////////////////////////////////////////////////////////////////////////////

--- a/src/mw.h
+++ b/src/mw.h
@@ -456,6 +456,7 @@ void cliProcess(void);
 void gpsInit(uint8_t baudrate);
 void gpsThread(void);
 void gpsSetPIDs(void);
+int8_t gpsSetPassthrough(void);
 void GPS_reset_home_position(void);
 void GPS_reset_nav(void);
 void GPS_set_next_wp(int32_t* lat, int32_t* lon);


### PR DESCRIPTION
The commands name is `gpspassthrough`, maybe make it shorter?

Maybe add optional argument for baudrate? (indexed, so 0=115200 etc)

If we should add the argument, how to explain it? Help option? Currently no other command has optional arguments that runs stuff when called without an option, they always seem to display some kind of a list.

Maybe `gpspassthrough -1` (or `*`?) goes on as current baudrate, or it takes an index `gpspassthrough [0-4]`. That way we can have a help text displayed with no arguments?
