### PR TITLE
Fixes array out of bound access in expo functions

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -69,18 +69,18 @@ void readEEPROM(void)
         mcfg.current_profile = 0;
     memcpy(&cfg, &mcfg.profile[mcfg.current_profile], sizeof(config_t));
 
-    for (i = 0; i < 6; i++)
+    for (i = 0; i < PITCH_LOOKUP_LENGTH; i++)
         lookupPitchRollRC[i] = (2500 + cfg.rcExpo8 * (i * i - 25)) * i * (int32_t) cfg.rcRate8 / 2500;
 
-    for (i = 0; i < 11; i++) {
+    for (i = 0; i < THROTTLE_LOOKUP_LENGTH; i++) {
         int16_t tmp = 10 * i - cfg.thrMid8;
         uint8_t y = 1;
         if (tmp > 0)
             y = 100 - cfg.thrMid8;
         if (tmp < 0)
             y = cfg.thrMid8;
-        lookupThrottleRC[i] = 10 * cfg.thrMid8 + tmp * (100 - cfg.thrExpo8 + (int32_t) cfg.thrExpo8 * (tmp * tmp) / (y * y)) / 10;      // [0;1000]
-        lookupThrottleRC[i] = mcfg.minthrottle + (int32_t) (mcfg.maxthrottle - mcfg.minthrottle) * lookupThrottleRC[i] / 1000;     // [0;1000] -> [MINTHROTTLE;MAXTHROTTLE]
+        lookupThrottleRC[i] = 10 * cfg.thrMid8 + tmp * (100 - cfg.thrExpo8 + (int32_t) cfg.thrExpo8 * (tmp * tmp) / (y * y)) / 10;
+        lookupThrottleRC[i] = mcfg.minthrottle + (int32_t) (mcfg.maxthrottle - mcfg.minthrottle) * lookupThrottleRC[i] / 1000; // [MINTHROTTLE;MAXTHROTTLE]
     }
 
     setPIDController(cfg.pidController);

--- a/src/mw.c
+++ b/src/mw.c
@@ -18,8 +18,8 @@ int16_t failsafeCnt = 0;
 int16_t failsafeEvents = 0;
 int16_t rcData[RC_CHANS];       // interval [1000;2000]
 int16_t rcCommand[4];           // interval [1000;2000] for THROTTLE and [-500;+500] for ROLL/PITCH/YAW
-int16_t lookupPitchRollRC[6];   // lookup table for expo & RC rate PITCH+ROLL
-int16_t lookupThrottleRC[11];   // lookup table for expo & mid THROTTLE
+int16_t lookupPitchRollRC[PITCH_LOOKUP_LENGTH];     // lookup table for expo & RC rate PITCH+ROLL
+int16_t lookupThrottleRC[THROTTLE_LOOKUP_LENGTH];   // lookup table for expo & mid THROTTLE
 uint16_t rssi;                  // range: [0;1023]
 rcReadRawDataPtr rcReadRawFunc = NULL;  // receive data from default (pwm/ppm) or additional (spek/sbus/?? receiver drivers)
 

--- a/src/mw.h
+++ b/src/mw.h
@@ -356,9 +356,12 @@ extern int16_t rcData[RC_CHANS];
 extern uint16_t rssi;                  // range: [0;1023]
 extern uint8_t vbat;
 extern int16_t telemTemperature1;      // gyro sensor temperature
-extern int16_t lookupPitchRollRC[6];   // lookup table for expo & RC rate PITCH+ROLL
-extern int16_t lookupThrottleRC[11];   // lookup table for expo & mid THROTTLE
 extern uint8_t toggleBeep;
+
+#define PITCH_LOOKUP_LENGTH 7
+#define THROTTLE_LOOKUP_LENGTH 12
+extern int16_t lookupPitchRollRC[PITCH_LOOKUP_LENGTH];   // lookup table for expo & RC rate PITCH+ROLL
+extern int16_t lookupThrottleRC[THROTTLE_LOOKUP_LENGTH];   // lookup table for expo & mid THROTTLE
 
 // GPS stuff
 extern int32_t  GPS_coord[2];


### PR DESCRIPTION
Both arrays lookupPitchRollRC and lookupThrottleRC were prone to an array out of bound access. Now they are big enough that this cannot happen anymore. The initialization of the arrays was also adjusted as well to set up the required values correctly.
