### PR TITLE
Start Frsky telemetry using a switch without beeing armed.

### DIFF
--- a/src/mw.h
+++ b/src/mw.h
@@ -101,6 +101,7 @@ enum {
     BOXCALIB,
     BOXGOV,
     BOXOSD,
+    BOXTELEMETRY,
     CHECKBOXITEMS
 };
 

--- a/src/serial.c
+++ b/src/serial.c
@@ -84,6 +84,7 @@ struct box_t {
     { BOXCALIB, "CALIB;", 17 },
     { BOXGOV, "GOVERNOR;", 18 },
     { BOXOSD, "OSD SW;", 19 },
+    { BOXTELEMETRY, "TELEMETRY;", 20 },
     { CHECKBOXITEMS, NULL, 0xFF }
 };
 
@@ -265,6 +266,8 @@ void serialInit(uint32_t baudrate)
     if (feature(FEATURE_INFLIGHT_ACC_CAL))
         availableBoxes[idx++] = BOXCALIB;
     availableBoxes[idx++] = BOXOSD;
+    if (feature(FEATURE_TELEMETRY))
+        availableBoxes[idx++] = BOXTELEMETRY;
     numberBoxItems = idx;
 }
 
@@ -379,6 +382,7 @@ static void evaluateCommand(void)
                     rcOptions[BOXCALIB] << BOXCALIB |
                     rcOptions[BOXGOV] << BOXGOV |
                     rcOptions[BOXOSD] << BOXOSD |
+                    rcOptions[BOXTELEMETRY] << BOXTELEMETRY |
                     f.ARMED << BOXARM;
         for (i = 0; i < numberBoxItems; i++) {
             int flag = (tmp & (1 << availableBoxes[i]));

--- a/src/telemetry.c
+++ b/src/telemetry.c
@@ -228,7 +228,7 @@ void initTelemetry(void)
 
 void updateTelemetryState(void)
 {
-    bool State = mcfg.telemetry_softserial != TELEMETRY_UART ? true : f.ARMED;
+    bool State = mcfg.telemetry_softserial != TELEMETRY_UART ? true : (f.ARMED || rcOptions[BOXTELEMETRY]);
 
     if (State != telemetryEnabled) {
         if (mcfg.telemetry_softserial == TELEMETRY_UART) {
@@ -246,7 +246,7 @@ static uint8_t cycleNum = 0;
 
 void sendTelemetry(void)
 {
-    if (mcfg.telemetry_softserial == TELEMETRY_UART && !f.ARMED)
+    if (mcfg.telemetry_softserial == TELEMETRY_UART && !f.ARMED && !rcOptions[BOXTELEMETRY])
         return;
 
     if (serialTotalBytesWaiting(core.telemport) != 0)


### PR DESCRIPTION
This adds a Telemetry checkbox in the gui.
If checked, it starts telemetry whatever it's armed or not.
