### PR TITLE
added option to disable setting motors to minthrottle

### DIFF
--- a/src/cli.c
+++ b/src/cli.c
@@ -116,6 +116,7 @@ const clivalue_t valueTable[] = {
     { "mincommand", VAR_UINT16, &mcfg.mincommand, 0, 2000 },
     { "mincheck", VAR_UINT16, &mcfg.mincheck, 0, 2000 },
     { "maxcheck", VAR_UINT16, &mcfg.maxcheck, 0, 2000 },
+    { "disable_set_minthrottle", VAR_UINT8, &mcfg.disable_set_minthrottle, 0, 1 },
     { "deadband3d_low", VAR_UINT16, &mcfg.deadband3d_low, 0, 2000 },
     { "deadband3d_high", VAR_UINT16, &mcfg.deadband3d_high, 0, 2000 },
     { "neutral3d", VAR_UINT16, &mcfg.neutral3d, 0, 2000 },

--- a/src/config.c
+++ b/src/config.c
@@ -13,7 +13,7 @@ master_t mcfg;  // master config struct with data independent from profiles
 config_t cfg;   // profile config struct
 const char rcChannelLetters[] = "AERT1234";
 
-static const uint8_t EEPROM_CONF_VERSION = 56;
+static const uint8_t EEPROM_CONF_VERSION = 57;
 static uint32_t enabledSensors = 0;
 static void resetConf(void);
 
@@ -203,6 +203,7 @@ static void resetConf(void)
     // Motor/ESC/Servo
     mcfg.minthrottle = 1150;
     mcfg.maxthrottle = 1850;
+    mcfg.disable_set_minthrottle = 0;
     mcfg.mincommand = 1000;
     mcfg.deadband3d_low = 1406;
     mcfg.deadband3d_high = 1514;

--- a/src/mixer.c
+++ b/src/mixer.c
@@ -386,6 +386,9 @@ void mixTable(void)
         // prevent "yaw jump" during yaw correction
         axisPID[YAW] = constrain(axisPID[YAW], -100 - abs(rcCommand[YAW]), +100 + abs(rcCommand[YAW]));
     }
+    
+    if((rcData[THROTTLE] < mcfg.mincheck) && (mcfg.disable_set_minthrottle) && (abs(vario) < 20))
+        axisPID[YAW] = 0;        
 
     // motors for non-servo mixes
     if (numberMotor > 1)
@@ -493,9 +496,9 @@ void mixTable(void)
         } else {
             motor[i] = constrain(motor[i], mcfg.minthrottle, mcfg.maxthrottle);
             if ((rcData[THROTTLE]) < mcfg.mincheck) {
-                if (!feature(FEATURE_MOTOR_STOP))
+                if (!mcfg.disable_set_minthrottle)
                     motor[i] = mcfg.minthrottle;
-                else
+                else if(feature(FEATURE_MOTOR_STOP))
                     motor[i] = mcfg.mincommand;
             }
         }

--- a/src/mw.h
+++ b/src/mw.h
@@ -227,6 +227,7 @@ typedef struct master_t {
     // motor/esc/servo related stuff
     uint16_t minthrottle;                   // Set the minimum throttle command sent to the ESC (Electronic Speed Controller). This is the minimum value that allow motors to run at a idle speed.
     uint16_t maxthrottle;                   // This is the maximum value for the ESCs at full power this value can be increased up to 2000
+    uint8_t  disable_set_minthrottle;       // disable setting motors to minthrottle when throttle stick is low
     uint16_t mincommand;                    // This is the value for the ESCs when they are not armed. In some cases, this value must be lowered down to 900 for some specific ESCs
     uint16_t deadband3d_low;                // min 3d value
     uint16_t deadband3d_high;               // max 3d value


### PR DESCRIPTION
That way the copter still stabilizes its self when throttle is at minimum.
imho a good addition.
