### PR TITLE
Enable gimbal_flags servo passthrough in airplane mode and other mixer modes that use servos

### DIFF
--- a/src/mixer.c
+++ b/src/mixer.c
@@ -471,8 +471,8 @@ void mixTable(void)
     // forward AUX1-4 to servo outputs (not constrained)
     if (cfg.gimbal_flags & GIMBAL_FORWARDAUX) {
         int offset = 0;
-        //offset servos based off number already used in mixer types
-        //airplane and servo_tilt together can't be used
+        // offset servos based off number already used in mixer types
+        // airplane and servo_tilt together can't be used
         if (mcfg.mixerConfiguration == MULTITYPE_AIRPLANE || mcfg.mixerConfiguration == MULTITYPE_FLYING_WING)
             offset = 4;
         else if (mixers[mcfg.mixerConfiguration].useServo)


### PR DESCRIPTION
The-kenny found that gimbal_flags=4 broke some stuff in airplane mode, this should fix it up
