### PR TITLE
Have servos output midrc at startup 

### DIFF
--- a/src/drv_pwm.c
+++ b/src/drv_pwm.c
@@ -376,7 +376,7 @@ bool pwmInit(drv_pwm_config_t *init)
 
             motors[numMotors++] = pwmOutConfig(port, mhz, hz / init->motorPwmRate, init->idlePulse);
         } else if (mask & TYPE_S) {
-            servos[numServos++] = pwmOutConfig(port, PWM_TIMER_MHZ, 1000000 / init->servoPwmRate, PULSE_1MS);
+            servos[numServos++] = pwmOutConfig(port, PWM_TIMER_MHZ, 1000000 / init->servoPwmRate, init->servoCenterPulse);
         }
     }
 

--- a/src/drv_pwm.h
+++ b/src/drv_pwm.h
@@ -18,6 +18,7 @@ typedef struct drv_pwm_config_t {
     uint16_t servoPwmRate;
     uint16_t idlePulse;  // PWM value to use when initializing the driver. set this to either PULSE_1MS (regular pwm), 
                          // some higher value (used by 3d mode), or 0, for brushed pwm drivers.
+    uint16_t servoCenterPulse;
     uint16_t failsafeThreshold;
 } drv_pwm_config_t;
 

--- a/src/main.c
+++ b/src/main.c
@@ -73,6 +73,7 @@ int main(void)
         pwm_params.idlePulse = mcfg.neutral3d;
     if (pwm_params.motorPwmRate > 500)
         pwm_params.idlePulse = 0; // brushed motors
+    pwm_params.servoCenterPulse = mcfg.midrc;
     pwm_params.failsafeThreshold = cfg.failsafe_detect_threshold;
     switch (mcfg.power_adc_channel) {
         case 1:


### PR DESCRIPTION
instead of 1ms pulse (full deflection)

Currently servos are pushed to one extreme on startup before the rest of the inits are done, this change will keep them centered on startup
