### PR TITLE
Add support for 2 softserial ports and avoid polling of software serial RX pins

### DIFF
--- a/src/cli.c
+++ b/src/cli.c
@@ -126,8 +126,9 @@ const clivalue_t valueTable[] = {
     { "flaps_speed", VAR_UINT8, &mcfg.flaps_speed, 0, 100 },
     { "fixedwing_althold_dir", VAR_INT8, &mcfg.fixedwing_althold_dir, -1, 1 },
     { "serial_baudrate", VAR_UINT32, &mcfg.serial_baudrate, 1200, 115200 },
-    { "softserial_baudrate", VAR_UINT32, &mcfg.softserial_baudrate, 600, 19200 },
-    { "softserial_inverted", VAR_UINT8, &mcfg.softserial_inverted, 0, 1 },
+    { "softserial_baudrate", VAR_UINT32, &mcfg.softserial_baudrate, 1200, 19200 },
+    { "softserial_1_inverted", VAR_UINT8, &mcfg.softserial_1_inverted, 0, 1 },
+    { "softserial_2_inverted", VAR_UINT8, &mcfg.softserial_2_inverted, 0, 1 },
     { "gps_type", VAR_UINT8, &mcfg.gps_type, 0, 3 },
     { "gps_baudrate", VAR_INT8, &mcfg.gps_baudrate, -1, 4 },
     { "serialrx_type", VAR_UINT8, &mcfg.serialrx_type, 0, 3 },
@@ -834,12 +835,12 @@ static void cliSave(char *cmdline)
 static void cliPrint(const char *str)
 {
     while (*str)
-        uartWrite(core.mainport, *(str++));
+        serialWrite(core.mainport, *(str++));
 }
 
 static void cliWrite(uint8_t ch)
 {
-    uartWrite(core.mainport, ch);
+    serialWrite(core.mainport, ch);
 }
 
 static void cliPrintVar(const clivalue_t *var, uint32_t full)

--- a/src/config.c
+++ b/src/config.c
@@ -13,7 +13,7 @@ master_t mcfg;  // master config struct with data independent from profiles
 config_t cfg;   // profile config struct
 const char rcChannelLetters[] = "AERT1234";
 
-static const uint8_t EEPROM_CONF_VERSION = 58;
+static const uint8_t EEPROM_CONF_VERSION = 59;
 static uint32_t enabledSensors = 0;
 static void resetConf(void);
 
@@ -216,7 +216,8 @@ static void resetConf(void)
     // serial (USART1) baudrate
     mcfg.serial_baudrate = 115200;
     mcfg.softserial_baudrate = 19200;
-    mcfg.softserial_inverted = 0;
+    mcfg.softserial_1_inverted = 0;
+    mcfg.softserial_2_inverted = 0;
     mcfg.looptime = 3500;
     mcfg.rssi_aux_channel = 0;
 

--- a/src/drv_pwm.c
+++ b/src/drv_pwm.c
@@ -236,7 +236,7 @@ static pwmPortData_t *pwmInConfig(uint8_t port, timerCCCallbackPtr callback, uin
     pwmGPIOConfig(timerHardwarePtr->gpio, timerHardwarePtr->pin, Mode_IPD);
     pwmICConfig(timerHardwarePtr->tim, timerHardwarePtr->channel, TIM_ICPolarity_Rising);
 
-    timerInConfig(timerHardwarePtr, 0xFFFF, PWM_TIMER_MHZ);
+    timerConfigure(timerHardwarePtr, 0xFFFF, PWM_TIMER_MHZ);
     configureTimerCaptureCompareInterrupt(timerHardwarePtr, port, callback);
 
     return p;

--- a/src/drv_softserial.h
+++ b/src/drv_softserial.h
@@ -18,16 +18,16 @@ typedef struct softSerial_s {
     const timerHardware_t *txTimerHardware;
     volatile uint8_t txBuffer[SOFT_SERIAL_BUFFER_SIZE];
     
-    uint8_t          isSearchingForStopBit;
-    uint8_t          rxBitSelectionMask;
     uint8_t          isSearchingForStartBit;
+    uint8_t          rxBitIndex;
+    uint8_t          rxLastRiseAtBitIndex;
+    uint8_t          rxPinMode;
+
     uint8_t          isTransmittingData;
-    uint8_t          timerRxCounter;
-    uint8_t          timerTxCounter;
-    uint8_t          bitsLeftToReceive;
     uint8_t          bitsLeftToTransmit;
-    uint16_t         internalRxBuffer;  // excluding start/stop bits
+
     uint16_t         internalTxBuffer;  // includes start and stop bits
+    uint16_t         internalRxBuffer;  // includes start and stop bits
 
     uint8_t          isInverted;
 } softSerial_t;
@@ -37,7 +37,8 @@ extern softSerial_t softSerialPorts[];
 
 extern const struct serialPortVTable softSerialVTable[];
 
-void setupSoftSerial1(uint32_t baud, uint8_t inverted);
+void setupSoftSerialPrimary(uint32_t baud, uint8_t inverted);
+void setupSoftSerialSecondary(uint8_t inverted);
 
 // serialPort API
 void softSerialWriteByte(serialPort_t *instance, uint8_t ch);

--- a/src/drv_timer.c
+++ b/src/drv_timer.c
@@ -134,7 +134,7 @@ void configureTimerCaptureCompareInterrupt(const timerHardware_t *timerHardwareP
     configureTimerInputCaptureCompareChannel(timerHardwarePtr->tim, timerHardwarePtr->channel);
 }
 
-void timerNVICConfig(uint8_t irq)
+void timerNVICConfigure(uint8_t irq)
 {
     NVIC_InitTypeDef NVIC_InitStructure;
 
@@ -162,11 +162,11 @@ void configTimeBase(TIM_TypeDef *tim, uint16_t period, uint8_t mhz)
     TIM_TimeBaseInit(tim, &TIM_TimeBaseStructure);
 }
 
-void timerInConfig(const timerHardware_t *timerHardwarePtr, uint16_t period, uint8_t mhz)
+void timerConfigure(const timerHardware_t *timerHardwarePtr, uint16_t period, uint8_t mhz)
 {
     configTimeBase(timerHardwarePtr->tim, period, mhz);
     TIM_Cmd(timerHardwarePtr->tim, ENABLE);
-    timerNVICConfig(timerHardwarePtr->irq);
+    timerNVICConfigure(timerHardwarePtr->irq);
 }
 
 

--- a/src/drv_timer.h
+++ b/src/drv_timer.h
@@ -14,8 +14,8 @@ typedef struct {
 extern const timerHardware_t timerHardware[];
 
 void configTimeBase(TIM_TypeDef *tim, uint16_t period, uint8_t mhz);
-void timerInConfig(const timerHardware_t *timerHardwarePtr, uint16_t period, uint8_t mhz);
-void timerNVICConfig(uint8_t irq);
+void timerConfigure(const timerHardware_t *timerHardwarePtr, uint16_t period, uint8_t mhz);
+void timerNVICConfigure(uint8_t irq);
 
 void configureTimerInputCaptureCompareChannel(TIM_TypeDef *tim, const uint8_t channel);
 void configureTimerCaptureCompareInterrupt(const timerHardware_t *timerHardwarePtr, uint8_t reference, timerCCCallbackPtr *callback);

--- a/src/mw.h
+++ b/src/mw.h
@@ -276,8 +276,9 @@ typedef struct master_t {
 
     uint32_t serial_baudrate;
 
-    uint32_t softserial_baudrate;
-    uint8_t softserial_inverted;            // use inverted softserial input and output signals
+    uint32_t softserial_baudrate;             // shared by both soft serial ports
+    uint8_t softserial_1_inverted;            // use inverted softserial input and output signals on port 1
+    uint8_t softserial_2_inverted;            // use inverted softserial input and output signals on port 2
 
     uint8_t telemetry_softserial;           // Serial to use for Telemetry. 0:USART1, 1:SoftSerial1 (Enable FEATURE_SOFTSERIAL first)
     uint8_t telemetry_switch;               // Use aux channel to change serial output & baudrate( MSP / Telemetry ). It disables automatic switching to Telemetry when armed.


### PR DESCRIPTION
Add support for 2 softserial ports on PWM4+5/TIM3_CH1+2/PA6+PA7 and PWM6+7/TIM3_CH3+4/PB0+PB1.

The software serial ports share the same baud rate both both are independently invertible.

The configuration parameter for inverting software serial ports changed. Use 'softserial_1_inverted' and 'softserial_2_inverted'.

Updated software serial to monitor serial pins for signal changes instead
of periodically sampling pin signals.

When reading the data the timer used is synchronized to the falling edge
of the start bit which allows for better synchronization at higher
speeds.  The code has been tested OK from 1200 baud to 19200.  38400
baud was tested and partially usable but has been disabled because there
are too many transmit and receive errors, especially when transmitting
and receiving at the same time.

Due to the way a single timer is used for transmitting and receiving, if
data comes in while transmitting the system may incorrectly transmit a
short or long bit.  However at 19200 and below this didn't cause a
problem in the limited testing I performed.
