### PR TITLE
GPS: clean up NMEA autodetect-baud

### DIFF
--- a/src/cli.c
+++ b/src/cli.c
@@ -130,7 +130,7 @@ const clivalue_t valueTable[] = {
     { "softserial_1_inverted", VAR_UINT8, &mcfg.softserial_1_inverted, 0, 1 },
     { "softserial_2_inverted", VAR_UINT8, &mcfg.softserial_2_inverted, 0, 1 },
     { "gps_type", VAR_UINT8, &mcfg.gps_type, 0, 3 },
-    { "gps_baudrate", VAR_INT8, &mcfg.gps_baudrate, -1, 4 },
+    { "gps_baudrate", VAR_INT8, &mcfg.gps_baudrate, 0, 4 },
     { "serialrx_type", VAR_UINT8, &mcfg.serialrx_type, 0, 3 },
     { "telemetry_softserial", VAR_UINT8, &mcfg.telemetry_softserial, 0, 1 },
     { "telemetry_switch", VAR_UINT8, &mcfg.telemetry_switch, 0, 1 },

--- a/src/main.c
+++ b/src/main.c
@@ -113,9 +113,6 @@ int main(void)
     } else { // spektrum and GPS are mutually exclusive
         // Optional GPS - available in both PPM and PWM input mode, in PWM input, reduces number of available channels by 2.
         // gpsInit will return if FEATURE_GPS is not enabled.
-        // Sanity check below - protocols other than NMEA do not support baud rate autodetection
-        if (mcfg.gps_type > 0 && mcfg.gps_baudrate < 0)
-            mcfg.gps_baudrate = 0;
         gpsInit(mcfg.gps_baudrate);
     }
 #ifdef SONAR

--- a/src/mw.h
+++ b/src/mw.h
@@ -272,7 +272,7 @@ typedef struct master_t {
 
     // gps-related stuff
     uint8_t gps_type;                       // Type of GPS hardware. 0: NMEA 1: UBX 2: MTK NMEA 3: MTK Binary
-    int8_t gps_baudrate;                    // GPS baudrate, -1: autodetect (NMEA only), 0: 115200, 1: 57600, 2: 38400, 3: 19200, 4: 9600
+    int8_t gps_baudrate;                    // GPS baudrate, 0: 115200, 1: 57600, 2: 38400, 3: 19200, 4: 9600. NMEA will cycle through these until valid data is received
 
     uint32_t serial_baudrate;
 


### PR DESCRIPTION
Removes gps_baudrate=-1 option. I didn't force NMEA to be 9600 because it can be configured to run on higher baudrate.
