### PR TITLE
Decouple reading EEPROM from writing EEPROM.

### DIFF
--- a/src/cli.c
+++ b/src/cli.c
@@ -826,7 +826,8 @@ static void cliProfile(char *cmdline)
         i = atoi(cmdline);
         if (i >= 0 && i <= 2) {
             mcfg.current_profile = i;
-            writeEEPROM(0, false);
+            writeEEPROM();
+            readEEPROM();
             cliProfile("");
         }
     }
@@ -835,7 +836,8 @@ static void cliProfile(char *cmdline)
 static void cliSave(char *cmdline)
 {
     cliPrint("Saving...");
-    writeEEPROM(0, true);
+    copyCurrentProfileToProfileSlot(mcfg.current_profile);
+    writeEEPROM();
     cliPrint("\r\nRebooting...");
     delay(10);
     systemReset(false);

--- a/src/mw.c
+++ b/src/mw.c
@@ -581,7 +581,8 @@ void loop(void)
                     i = 3;
                 if (i) {
                     mcfg.current_profile = i - 1;
-                    writeEEPROM(0, false);
+                    writeEEPROM();
+                    readEEPROM();
                     blinkLED(2, 40, i);
                     // TODO alarmArray[0] = i;
                 }
@@ -614,7 +615,9 @@ void loop(void)
                     i = 1;
                 }
                 if (i) {
-                    writeEEPROM(1, true);
+                    copyCurrentProfileToProfileSlot(mcfg.current_profile);
+                    writeEEPROM();
+                    readEEPROMAndNotify();
                     rcDelayCommand = 0; // allow autorepetition
                 }
             }

--- a/src/mw.h
+++ b/src/mw.h
@@ -439,9 +439,10 @@ void serialCom(void);
 // Config
 void parseRcChannels(const char *input);
 void activateConfig(void);
-void loadAndActivateConfig(void);
+void copyCurrentProfileToProfileSlot(uint8_t profileSlotIndex);
 void readEEPROM(void);
-void writeEEPROM(uint8_t b, uint8_t updateProfile);
+void readEEPROMAndNotify(void);
+void writeEEPROM();
 void checkFirstTime(bool reset);
 bool sensors(uint32_t mask);
 void sensorsSet(uint32_t mask);

--- a/src/sensors.c
+++ b/src/sensors.c
@@ -182,7 +182,9 @@ static void ACC_Common(void)
             mcfg.accZero[YAW] = (a[YAW] + (CALIBRATING_ACC_CYCLES / 2)) / CALIBRATING_ACC_CYCLES - acc_1G;
             cfg.angleTrim[ROLL] = 0;
             cfg.angleTrim[PITCH] = 0;
-            writeEEPROM(1, true);      // write accZero in EEPROM
+            copyCurrentProfileToProfileSlot(mcfg.current_profile);
+            writeEEPROM();      // write accZero in EEPROM
+            readEEPROMAndNotify();
         }
         calibratingA--;
     }
@@ -232,7 +234,9 @@ static void ACC_Common(void)
             mcfg.accZero[YAW] = b[YAW] / 50 - acc_1G;    // for nunchuk 200=1G
             cfg.angleTrim[ROLL] = 0;
             cfg.angleTrim[PITCH] = 0;
-            writeEEPROM(1, true);          // write accZero in EEPROM
+            copyCurrentProfileToProfileSlot(mcfg.current_profile);
+            writeEEPROM();      // write accZero in EEPROM
+            readEEPROMAndNotify();
         }
     }
 
@@ -428,7 +432,10 @@ int Mag_getADC(void)
             tCal = 0;
             for (axis = 0; axis < 3; axis++)
                 mcfg.magZero[axis] = (magZeroTempMin[axis] + magZeroTempMax[axis]) / 2; // Calculate offsets
-            writeEEPROM(1, true);
+
+            copyCurrentProfileToProfileSlot(mcfg.current_profile);
+            writeEEPROM();
+            readEEPROMAndNotify();
         }
     }
 

--- a/src/serial.c
+++ b/src/serial.c
@@ -350,8 +350,8 @@ static void evaluateCommand(void)
             mcfg.current_profile = read8();
             if (mcfg.current_profile > 2)
                 mcfg.current_profile = 0;
-            // this writes new profile index and re-reads it
-            writeEEPROM(0, false);
+            writeEEPROM();
+            readEEPROM();
         }
         headSerialReply(0);
         break;
@@ -593,7 +593,9 @@ static void evaluateCommand(void)
         if (f.ARMED) {
             headSerialError(0);
         } else {
-            writeEEPROM(0, true);
+            copyCurrentProfileToProfileSlot(mcfg.current_profile);
+            writeEEPROM();
+            readEEPROM();
             headSerialReply(0);
         }
         break;


### PR DESCRIPTION
Now writeEEPROM() does only what it's name implies and it's method takes no arguments.  This
avoids the 0/1 magic numbers which was a flag to decide whether the user
should be notified after the EEPROM has been read (!).

Introduced a method called readEEPROMAndNotify() which is used in all
cases where writeEEPROM(1) was previously called.

Additionally this avoid re-reading the profile when the reboot command
is issued which speeds up reboots.

Finally this avoid needless comments because the code tells you now what
it is going to do.
