### PR TITLE
 BUG FIX - Fixes 3d flight mixer so that it uses midrc

### DIFF
--- a/src/mixer.c
+++ b/src/mixer.c
@@ -487,7 +487,7 @@ void mixTable(void)
         if (maxMotor > mcfg.maxthrottle)     // this is a way to still have good gyro corrections if at least one motor reaches its max.
             motor[i] -= maxMotor - mcfg.maxthrottle;
         if (feature(FEATURE_3D)) {
-            if ((rcData[THROTTLE]) > 1500) {
+            if ((rcData[THROTTLE]) > mcfg.midrc) {
                 motor[i] = constrain(motor[i], mcfg.deadband3d_high, mcfg.maxthrottle);
             } else {
                 motor[i] = constrain(motor[i], mcfg.mincommand, mcfg.deadband3d_low);


### PR DESCRIPTION
Previously it was using a hardcoded value of 1500.

Without this commit it would mean that any midrc configuration was not
being applied to 3d flight.

Confirmed with Nicolas Grunbaum.
