### PR TITLE
Enable input filtering on input capture timers.

### DIFF
--- a/src/drv_pwm.c
+++ b/src/drv_pwm.c
@@ -182,7 +182,7 @@ void pwmICConfig(TIM_TypeDef *tim, uint8_t channel, uint16_t polarity)
     TIM_ICInitStructure.TIM_ICPolarity = polarity;
     TIM_ICInitStructure.TIM_ICSelection = TIM_ICSelection_DirectTI;
     TIM_ICInitStructure.TIM_ICPrescaler = TIM_ICPSC_DIV1;
-    TIM_ICInitStructure.TIM_ICFilter = 0x0;
+    TIM_ICInitStructure.TIM_ICFilter = 0x03;
 
     TIM_ICInit(tim, &TIM_ICInitStructure);
 }


### PR DESCRIPTION
This enables 8 sample long filtering on input capture timer, this has been seen to remove glitching in some cases (with receivers that transmit telemetry packets). There is virtually zero negative effects from this change as it delays the edge detection by negletible amount of time.
