### PR TITLE
BUGFIX - Linker script for F10x was not reserving the last 2kb which

### DIFF
--- a/stm32_flash.ld
+++ b/stm32_flash.ld
@@ -22,7 +22,7 @@ _Min_Stack_Size = 0x400; /* required amount of stack */
 /* Specify the memory areas */
 MEMORY
 {
-  FLASH (rx)      : ORIGIN = 0x08000000, LENGTH = 127K
+  FLASH (rx)      : ORIGIN = 0x08000000, LENGTH = 126K /* last 2kb used for config storage */
   RAM (xrw)       : ORIGIN = 0x20000000, LENGTH = 20K
   MEMORY_B1 (rx)  : ORIGIN = 0x60000000, LENGTH = 0K
 }


### PR DESCRIPTION
meant that 1kb of code could be overwritten when saving the config.
