### PR TITLE
custom commands for MCFG INFO,READ,WRITE,REBOOT aka MSP_PRIVATE

### DIFF
--- a/src/serial.c
+++ b/src/serial.c
@@ -401,6 +401,10 @@ static void evaluateCommand(void)
         }
         break;
     case MSP_BF_REBOOT:
+        headSerialReply(1);
+        serialize8(1);
+        tailSerialReply();
+        delay(100);
         systemReset(read8());
         break;
     case MSP_IDENT:


### PR DESCRIPTION
First of all, i don't really expect this to be merged, i just wanted to get it out there, it might inspire the rest of BF developers to come up with some nicer solution for handling "extra/custom" configuration that is currently only possible through CLI.

MSP_MCFG_INFO is tested and works accordingly
MSP_MCFG_READ is tested and works accordingly (as far i can tell from my proof of concept configurator code)
MSP_MCFG_WRITE is currently untested (it would require quite a bit more of proof of concept code, if this approach has a chance of getting merged i will write the needed code and test the code accordingly, however i don't see why it shouldn't work its pretty much just a reverse clone of MSP_MCFG_READ.
MSP_BF_REBOOT tested, works accordingly

I should also note that this approach will suffer from the expected versioning/struct reconstruction issues because the union data needs to be reconstructed on the js side (usually manually/hardcoded) since there is no data being provided from the firmware about struct variable names or their sizes.
Any chance that requires an mcfg.version change will require different reconstruction. :/
