### PR TITLE
headfree gyro

### DIFF
--- a/src/imu.c
+++ b/src/imu.c
@@ -265,6 +265,8 @@ static void getEstimatedAttitude(void)
         rotateV(&EstM.V, deltaGyroAngle);
     } else {
         rotateV(&EstN.V, deltaGyroAngle);
+        if(EstG.A[Z] > (smallAngle*2))
+            EstN.V.Z = 0;
         normalizeV(&EstN.V, &EstN.V);
     }
 


### PR DESCRIPTION
there is nothing that prevent the vector to pointing donward or upward. 
we could apply a threshold to deltaGyroAngle before rotateV , we could use the calibration phase to found the threshold value OR we can just flatten the vector at small angle.
