### PR TITLE
Make code warnings-free with -pedantic, this should guard against more programming errors in the future

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -161,7 +161,8 @@ CFLAGS		 = $(ARCH_FLAGS) \
 		   $(addprefix -D,$(OPTIONS)) \
 		   $(addprefix -I,$(INCLUDE_DIRS)) \
 		   $(DEBUG_FLAGS) \
-		   -Wall \
+		   -std=gnu99 \
+		   -Wall -pedantic \
 		   -ffunction-sections \
 		   -fdata-sections \
 		   -DSTM32F10X_MD \

--- a/src/drv_serial.h
+++ b/src/drv_serial.h
@@ -42,11 +42,11 @@ struct serialPortVTable {
     void (*setMode)(serialPort_t *instance, portMode_t mode);
 };
 
-inline void serialWrite(serialPort_t *instance, uint8_t ch);
-inline uint8_t serialTotalBytesWaiting(serialPort_t *instance);
-inline uint8_t serialRead(serialPort_t *instance);
-inline void serialSetBaudRate(serialPort_t *instance, uint32_t baudRate);
+void serialWrite(serialPort_t *instance, uint8_t ch);
+uint8_t serialTotalBytesWaiting(serialPort_t *instance);
+uint8_t serialRead(serialPort_t *instance);
+void serialSetBaudRate(serialPort_t *instance, uint32_t baudRate);
 void serialSetMode(serialPort_t *instance, portMode_t mode);
-inline bool isSerialTransmitBufferEmpty(serialPort_t *instance);
+bool isSerialTransmitBufferEmpty(serialPort_t *instance);
 void serialPrint(serialPort_t *instance, const char *str);
 uint32_t serialGetBaudRate(serialPort_t *instance);

--- a/src/telemetry_frsky.c
+++ b/src/telemetry_frsky.c
@@ -210,19 +210,6 @@ static void sendVoltage(void)
     currentCell %= batteryCellCount;
 }
 
-/*
- * Send voltage with ID_VOLTAGE_AMP
- */
-static void sendVoltageAmp(void)
-{
-    uint16_t voltage = (vbat * 110) / 21;
-
-    sendDataHead(ID_VOLTAGE_AMP_BP);
-    serialize16(voltage / 100);
-    sendDataHead(ID_VOLTAGE_AMP_AP);
-    serialize16(((voltage % 100) + 5) / 10);
-}
-
 static void sendAmperage(void)
 {
     sendDataHead(ID_CURRENT);


### PR DESCRIPTION
This removes a function that's no longer used, and inline specifiers
from include file (where they're useless anyway). This makes the whole
default project warnings-free with -Wall -pedantic.

Signed-off-by: Paul Fertser fercerpav@gmail.com
