### PR TITLE
Minor 'const' issue.

### DIFF
--- a/src/drv_timer.c
+++ b/src/drv_timer.c
@@ -75,7 +75,7 @@ const timerHardware_t timerHardware[] = {
 #define MAX_TIMERS 4 // TIM1..TIM4
 #define CC_CHANNELS_PER_TIMER 4 // TIM_Channel_1..4
 
-static const TIM_TypeDef *timers[MAX_TIMERS] = {
+static TIM_TypeDef * const timers[MAX_TIMERS] = {
     TIM1, TIM2, TIM3, TIM4
 };
 


### PR DESCRIPTION
I think there is a small issue relating to the positioning of a 'const' keyword in drv_timers.c. The offending line is...
(~line 78)
static const TIM_TypeDef *timers[MAX_TIMERS] = {

I believe that the intention of the 'const' is to get the table into ROM, but this is not happening.
Here is a snippet of the assembly output of this file when const is in this location...
    .data
    .align  2
    .type   timers, %object
    .size   timers, 16
timers:
    .word   1073818624
    .word   1073741824
    .word   1073742848
    .word   1073743872
    .section    .rodata
    .align  2
    .type   channels, %object
    .size   channels, 4
channels:

Note the line ".data" preceding .timers indicating that the following code is to be placed into the data section

If the const is moved here
static TIM_TypeDef \* const timers[MAX_TIMERS] = {
The assembly output becomes...

```
.section    .rodata
.align  2
.type   timerHardware, %object
.size   timerHardware, 224
```

timerHardware:
.
.
.
    .align  2
    .type   timers, %object
    .size   timers, 16
timers:

Note that 'timers' is in the .rodata section, which is what you're looking for.

Please consider this pull request for inclusion in the main project if you agree that it fixes a problem.
Note that I haven't looked for other instances where this issue might be present, but it might be worth having a look about for more cases.
