### PR TITLE
bugfix pt1 element

### DIFF
--- a/src/imu.c
+++ b/src/imu.c
@@ -173,6 +173,10 @@ void acc_calc(uint32_t deltaT)
     float rpy[3];
     t_fp_vector accel_ned;
 
+
+    // sum up Values for later integration to get velocity and distance
+    accTimeSum += deltaT;
+    accSumCount++;
     // deltaT is measured in us ticks
     deltaT *= 1e-6f;
 
@@ -202,10 +206,6 @@ void acc_calc(uint32_t deltaT)
     accSum[X] += applyDeadband(lrintf(accel_ned.V.X), cfg.accxy_deadband);
     accSum[Y] += applyDeadband(lrintf(accel_ned.V.Y), cfg.accxy_deadband);
     accSum[Z] += applyDeadband(lrintf(accz_smooth), cfg.accz_deadband);
-
-    // sum up Values for later integration to get velocity and distance
-    accTimeSum += deltaT;
-    accSumCount++;
 }
 
 void accSum_reset(void)


### PR DESCRIPTION
when copying code it should be placed in the correct context.
stupid bug - making the pt1 element unusable.
