### PR TITLE
Make disarming via AUX switch independent of throttle value configurable

### DIFF
--- a/src/cli.c
+++ b/src/cli.c
@@ -142,6 +142,7 @@ const clivalue_t valueTable[] = {
     { "motor_pwm_rate", VAR_UINT16, &mcfg.motor_pwm_rate, 50, 32000 },
     { "servo_pwm_rate", VAR_UINT16, &mcfg.servo_pwm_rate, 50, 498 },
     { "retarded_arm", VAR_UINT8, &mcfg.retarded_arm, 0, 1 },
+    { "disarm_kill_switch", VAR_UINT8, &mcfg.disarm_kill_switch, 0, 1 },
     { "flaps_speed", VAR_UINT8, &mcfg.flaps_speed, 0, 100 },
     { "fixedwing_althold_dir", VAR_INT8, &mcfg.fixedwing_althold_dir, -1, 1 },
     { "reboot_character", VAR_UINT8, &mcfg.reboot_character, 48, 126 },

--- a/src/config.c
+++ b/src/config.c
@@ -224,6 +224,7 @@ static void resetConf(void)
     mcfg.mincheck = 1100;
     mcfg.maxcheck = 1900;
     mcfg.retarded_arm = 0;       // disable arm/disarm on roll left/right
+    mcfg.disarm_kill_switch = 1; // AUX disarm independently of throttle value
     mcfg.flaps_speed = 0;
     mcfg.fixedwing_althold_dir = 1;
     // Motor/ESC/Servo

--- a/src/mw.c
+++ b/src/mw.c
@@ -552,8 +552,13 @@ void loop(void)
         }
 
         if (cfg.activate[BOXARM] > 0) { // Disarming via ARM BOX
-            if (!rcOptions[BOXARM] && f.ARMED)
+            if (!rcOptions[BOXARM] && f.ARMED) {
+                if (mcfg.disarm_kill_switch) {
                     mwDisarm();
+                } else if (isThrottleLow) {
+                    mwDisarm();
+                }
+            }
         }
 
         if (rcDelayCommand == 20) {

--- a/src/mw.h
+++ b/src/mw.h
@@ -278,6 +278,7 @@ typedef struct master_t {
     uint16_t mincheck;                      // minimum rc end
     uint16_t maxcheck;                      // maximum rc end
     uint8_t retarded_arm;                   // allow disarsm/arm on throttle down + roll left/right
+    uint8_t disarm_kill_switch;             // AUX disarm independently of throttle value
     uint8_t flaps_speed;                    // airplane mode flaps, 0 = no flaps, > 0 = flap speed, larger = faster
     int8_t fixedwing_althold_dir;           // +1 or -1 for pitch/althold gain. later check if need more than just sign
 


### PR DESCRIPTION
Adds a CLI config option to configure the AUX arm/disarm behaviour. 
Default (1) disarms immediately and independently of the throttle value. When set to 0 baseflight reverts to the old behaviour of only disarming when throttle is low.
