### PR TITLE
Number of telemetry ports needs to be reset to zero on each SerialInit...

### DIFF
--- a/src/serial.c
+++ b/src/serial.c
@@ -265,7 +265,7 @@ void serialInit(uint32_t baudrate)
 {
     int idx;
 
-	numTelemetryPorts = 0;
+    numTelemetryPorts = 0;
     core.mainport = uartOpen(USART1, NULL, baudrate, MODE_RXTX);
     ports[0].port = core.mainport;
     numTelemetryPorts++;


### PR DESCRIPTION
... call.

Otherwise the for-loop in SerialCom gets out of bounds and the Naze32 would lock up when armed (if feature TELEMETRY is enabled).
