### PR TITLE
Fix building CJMCU target with Makefile

### DIFF
--- a/src/sensors.c
+++ b/src/sensors.c
@@ -151,12 +151,14 @@ retry:
           }
         ; // fallthrough
           
+#ifdef NAZE
         case MAG_AK8975:
             if (ak8975detect(&mag)) {
                 magHardware = MAG_AK8975;
                 if (mcfg.mag_hardware == MAG_AK8975)
                     break;
             }
+#endif
     }
     
     // Found anything? Check if user fucked up or mag is really missing.


### PR DESCRIPTION
Building the CJMCU target with Makefile didn't work because the ak8975 driver isn't added to said target in the Makefile. Baseflight is trying to auto-init it in sensors.c nonetheless. Added defines for the NAZE target because that's the only one where it's used anyway.
