### PR TITLE
gyro zero mean calculation

### DIFF
--- a/src/sensors.c
+++ b/src/sensors.c
@@ -440,7 +440,7 @@ static void GYRO_Common(void)
                     g[0] = g[1] = g[2] = 0;
                     continue;
                 }
-                gyroZero[axis] = (g[axis] + (CALIBRATING_GYRO_CYCLES / 2)) / CALIBRATING_GYRO_CYCLES;
+                gyroZero[axis] = g[axis] / CALIBRATING_GYRO_CYCLES;
                 blinkLED(10, 15, 1);
             }
         }


### PR DESCRIPTION
I don't understand the current mean calculation of the gyro zero values. Why is 0.5 added to the zero value?
