### PR TITLE
Spektrum satellite binding improvement

### DIFF
--- a/src/spektrum.c
+++ b/src/spektrum.c
@@ -70,7 +70,7 @@ static void spektrumDataReceive(uint16_t c)
     if (spekFramePosition == SPEK_FRAME_SIZE - 1) {
         rcFrameComplete = true;
         failsafeCnt = 0;   // clear FailSafe counter
-        if(mcfg.spektrum_sat_bind != 0) {
+        if (mcfg.spektrum_sat_bind != 0) {
             mcfg.spektrum_sat_bind = 0;
             writeEEPROM(0, true);
         }


### PR DESCRIPTION
After this improvement user doesn't need to set spektrum_sat_bind back
to zero from CLI after binding the satellite. It is now set to zero
automatically after succesful binding.
