### PR TITLE
Fix for softserial code.

### DIFF
--- a/src/drv_softserial.c
+++ b/src/drv_softserial.c
@@ -338,7 +338,7 @@ void onSerialRxPinChange(uint8_t portIndex, uint16_t capture)
         // synchronise bit counter
         // FIXME this reduces functionality somewhat as receiving breaks concurrent transmission on all ports because
         // the next callback to the onSerialTimer will happen too early causing transmission errors.
-        TIM_SetCounter(softSerial->rxTimerHardware->tim, 0);
+        TIM_SetCounter(softSerial->rxTimerHardware->tim, softSerial->rxTimerHardware->tim->ARR / 2);
         if (softSerial->isTransmittingData) {
             softSerial->transmissionErrors++;
         }


### PR DESCRIPTION
"Bit end timer must by shifted by half-bit period to startbit edge, so that next edges are in middle of bit interval. This behavior was masked with old timer code, but noise immunity was probably very low."

-Backported from @ledvinap's code here. https://github.com/ledvinap/cleanflight/commit/3b20b74c0017fbc210a3091bf7ff4fbe42abfdf7#diff-0
