### PR TITLE
Remove un-used stuff, Keil now has no warnings.

### DIFF
--- a/src/drv_mma845x.c
+++ b/src/drv_mma845x.c
@@ -52,7 +52,6 @@
 #define MMA8452_CTRL_REG1_ACTIVE        0x01
 
 extern uint16_t acc_1G;
-static uint8_t device_id;
 static sensor_align_e accAlign = CW90_DEG;
 
 static void mma8452Init(sensor_align_e align);
@@ -73,7 +72,6 @@ bool mma8452Detect(sensor_t *acc)
 
     acc->init = mma8452Init;
     acc->read = mma8452Read;
-    device_id = sig;
     return true;
 }
 

--- a/src/gps.c
+++ b/src/gps.c
@@ -1269,7 +1269,6 @@ static uint16_t _payload_length;
 static uint16_t _payload_counter;
 
 static bool next_fix;
-static uint8_t _class;
 
 // do we have new position information?
 static bool _new_position;
@@ -1313,7 +1312,6 @@ static bool gpsNewFrameUBLOX(uint8_t data)
             break;
         case 2:
             _step++;
-            _class = data;
             _ck_b = _ck_a = data;   // reset the checksum accumulators
             break;
         case 3:


### PR DESCRIPTION
These 2 things caused warnings in Keil every time its compiled, they don't seem to be used for anything at all though?
