### PR TITLE
Adding additional servo for flap (fix)

### DIFF
--- a/src/mixer.c
+++ b/src/mixer.c
@@ -309,7 +309,7 @@ void writeServos(void)
             pwmWriteServo(1, servo[4]);
             pwmWriteServo(2, servo[5]);
             pwmWriteServo(3, servo[6]);
-            if(mcfg.fw_flaps)
+            if (mcfg.fw_flaps)
                 pwmWriteServo(4, servo[2]);
             break;
 


### PR DESCRIPTION
Servo 2 is used for a flap channel but it was not set to write in writeServo().
