### PR TITLE
Rename pitch/roll rate to 'throw', presenting fw_rth_alt as a CLI option.

### DIFF
--- a/src/cli.c
+++ b/src/cli.c
@@ -212,8 +212,8 @@ const clivalue_t valueTable[] = {
     { "rssi_adc_offset", VAR_INT16, &mcfg.rssi_adc_offset, 0, 4095 },
     { "yaw_direction", VAR_INT8, &cfg.yaw_direction, -1, 1 },
     { "tri_unarmed_servo", VAR_INT8, &cfg.tri_unarmed_servo, 0, 1 },
-    { "fw_rollrate", VAR_FLOAT, &cfg.fw_rollrate, 0, 1 },
-    { "fw_pitchrate", VAR_FLOAT, &cfg.fw_pitchrate, 0, 1 },
+    { "fw_roll_throw", VAR_FLOAT, &cfg.fw_roll_throw, 0, 1 },
+    { "fw_pitch_throw", VAR_FLOAT, &cfg.fw_pitch_throw, 0, 1 },
     { "fw_vector_trust", VAR_UINT8, &cfg.fw_vector_trust, 0, 1},
     { "gimbal_flags", VAR_UINT8, &cfg.gimbal_flags, 0, 255},
     { "acc_lpf_factor", VAR_UINT8, &cfg.acc_lpf_factor, 0, 250 },
@@ -270,6 +270,7 @@ const clivalue_t valueTable[] = {
     { "fw_idle_throttle", VAR_UINT16, &cfg.fw_idle_throttle, 1000, 2000 },
     { "fw_scaler_throttle", VAR_UINT16, &cfg.fw_scaler_throttle, 0, 15 },
     { "fw_roll_comp", VAR_FLOAT, &cfg.fw_roll_comp, 0, 2 },
+    { "fw_rth_alt", VAR_UINT8, &cfg.D8[PIDPOSR], 0, 200 },
 };
 
 #define VALUE_COUNT (sizeof(valueTable) / sizeof(clivalue_t))

--- a/src/config.c
+++ b/src/config.c
@@ -343,8 +343,8 @@ static void resetConf(void)
     cfg.nav_speed_max = 300;
     cfg.ap_mode = 40;
     // fw stuff
-    cfg.fw_rollrate = 0.5f;
-    cfg.fw_pitchrate = 0.5f;
+    cfg.fw_roll_throw = 0.5f;
+    cfg.fw_pitch_throw = 0.5f;
     cfg.fw_gps_maxcorr = 20;
     cfg.fw_gps_rudder = 15;
     cfg.fw_gps_maxclimb = 15;

--- a/src/mixer.c
+++ b/src/mixer.c
@@ -459,12 +459,12 @@ void mixTable(void)
 
             if (f.PASSTHRU_MODE) {
                 // do not use sensors for correction, simple 2 channel mixing
-                servo[3] = ((servoDirection(3, 1) * rcCommand[PITCH]) * cfg.fw_pitchrate) + ((servoDirection(3, 2) * rcCommand[ROLL]) * cfg.fw_rollrate);
-                servo[4] = ((servoDirection(4, 1) * rcCommand[PITCH]) * cfg.fw_pitchrate) + ((servoDirection(4, 2) * rcCommand[ROLL]) * cfg.fw_rollrate);
+                servo[3] = ((servoDirection(3, 1) * rcCommand[PITCH]) * cfg.fw_pitch_throw) + ((servoDirection(3, 2) * rcCommand[ROLL]) * cfg.fw_roll_throw);
+                servo[4] = ((servoDirection(4, 1) * rcCommand[PITCH]) * cfg.fw_pitch_throw) + ((servoDirection(4, 2) * rcCommand[ROLL]) * cfg.fw_roll_throw);
             } else {
                 // use sensors to correct (gyro only or gyro + acc)
-                servo[3] = ((servoDirection(3, 1) * axisPID[PITCH]) * cfg.fw_pitchrate) + ((servoDirection(3, 2) * axisPID[ROLL]) * cfg.fw_rollrate);
-                servo[4] = ((servoDirection(4, 1) * axisPID[PITCH]) * cfg.fw_pitchrate) + ((servoDirection(4, 2) * axisPID[ROLL]) * cfg.fw_rollrate);
+                servo[3] = ((servoDirection(3, 1) * axisPID[PITCH]) * cfg.fw_pitch_throw) + ((servoDirection(3, 2) * axisPID[ROLL]) * cfg.fw_roll_throw);
+                servo[4] = ((servoDirection(4, 1) * axisPID[PITCH]) * cfg.fw_pitch_throw) + ((servoDirection(4, 2) * axisPID[ROLL]) * cfg.fw_roll_throw);
             }
             servo[3] += servoMiddle(3);
             servo[4] += servoMiddle(4);

--- a/src/mw.h
+++ b/src/mw.h
@@ -230,8 +230,8 @@ typedef struct config_t {
     uint16_t nav_speed_max;                 // cm/sec
     uint16_t ap_mode;                       // Temporarily Disables GPS_HOLD_MODE to be able to make it possible to adjust the Hold-position when moving the sticks, creating a deadspan for GPS
 
-    float fw_rollrate;
-    float fw_pitchrate;
+    float fw_roll_throw;
+    float fw_pitch_throw;
     uint8_t fw_vector_trust;
     uint8_t fw_flaperons_invert;
     int16_t fw_gps_maxcorr;                    // Degrees banking Allowed by GPS.


### PR DESCRIPTION
1) Renaming 'rate' to 'throw' since this influences the percentage of usable servo movement, not the traditional 'rate'. Just to avoid confusion.
2) Presenting fw_rth_alt as a CLI option to make setting easier until configurator changes are made.
