### PR TITLE
Add support for a hardware bind plug (PB5 pin 41) and alternative

### DIFF
--- a/src/board.h
+++ b/src/board.h
@@ -223,7 +223,12 @@ typedef struct baro_t {
 #define LED0
 #define LED1
 #define INVERTER
+
+#ifndef ALIENWII32
 #define MOTOR_PWM_RATE 400
+#else
+#define MOTOR_PWM_RATE 32000
+#endif
 
 #define SENSORS_SET (SENSOR_ACC | SENSOR_BARO | SENSOR_MAG)
 #define I2C_DEVICE (I2CDEV_2)

--- a/src/cli.c
+++ b/src/cli.c
@@ -162,6 +162,7 @@ const clivalue_t valueTable[] = {
     { "gps_ubx_sbas", VAR_UINT8, &mcfg.gps_ubx_sbas, 0, 4 },
     { "serialrx_type", VAR_UINT8, &mcfg.serialrx_type, 0, SERIALRX_PROVIDER_MAX },
     { "spektrum_sat_bind", VAR_UINT8, &mcfg.spektrum_sat_bind, 0, 10 },
+    { "hardware_bind_plug", VAR_UINT8, &mcfg.hardware_bind_plug, 0, 1 },
     { "spektrum_sat_on_flexport", VAR_UINT8, &mcfg.spektrum_sat_on_flexport, 0, 1 },
     { "telemetry_provider", VAR_UINT8, &mcfg.telemetry_provider, 0, TELEMETRY_PROVIDER_MAX },
     { "telemetry_port", VAR_UINT8, &mcfg.telemetry_port, 0, TELEMETRY_PORT_MAX },

--- a/src/config.c
+++ b/src/config.c
@@ -24,7 +24,7 @@ master_t mcfg;  // master config struct with data independent from profiles
 config_t cfg;   // profile config struct
 const char rcChannelLetters[] = "AERT1234";
 
-static const uint8_t EEPROM_CONF_VERSION = 71;
+static const uint8_t EEPROM_CONF_VERSION = 72;
 static uint32_t enabledSensors = 0;
 static void resetConf(void);
 static const uint32_t FLASH_WRITE_ADDR = 0x08000000 + (FLASH_PAGE_SIZE * (FLASH_PAGE_COUNT - (CONFIG_SIZE / 1024)));
@@ -192,6 +192,10 @@ static void resetConf(void)
 #else
     featureSet(FEATURE_VBAT);
 #endif
+#ifdef ALIENWII32
+    featureSet(FEATURE_SERIALRX);
+    featureSet(FEATURE_MOTOR_STOP);
+#endif
 
     // global settings
     mcfg.current_profile = 0;       // default profile
@@ -217,7 +221,15 @@ static void resetConf(void)
     mcfg.vbatmaxcellvoltage = 43;
     mcfg.vbatmincellvoltage = 33;
     mcfg.power_adc_channel = 0;
+#ifndef ALIENWII32
     mcfg.serialrx_type = 0;
+    mcfg.hardware_bind_plug = 0;     // bind plug hardware not present
+    mcfg.spektrum_sat_bind = 0;
+#else
+    mcfg.serialrx_type = 1;
+    mcfg.hardware_bind_plug = 1;     // bind plug hardware is present
+    mcfg.spektrum_sat_bind = 5;
+#endif
     mcfg.telemetry_provider = TELEMETRY_PROVIDER_FRSKY;
     mcfg.telemetry_port = TELEMETRY_PORT_UART;
     mcfg.telemetry_switch = 0;
@@ -230,8 +242,13 @@ static void resetConf(void)
     mcfg.fw_flaperons_max = 2000;
     mcfg.fw_althold_dir = 1;
     // Motor/ESC/Servo
+#ifndef ALIENWII32
     mcfg.minthrottle = 1150;
     mcfg.maxthrottle = 1850;
+#else
+    mcfg.minthrottle = 1000;
+    mcfg.maxthrottle = 2000;
+#endif
     mcfg.mincommand = 1000;
     mcfg.deadband3d_low = 1406;
     mcfg.deadband3d_high = 1514;
@@ -281,10 +298,16 @@ static void resetConf(void)
     cfg.P8[PIDVEL] = 120;
     cfg.I8[PIDVEL] = 45;
     cfg.D8[PIDVEL] = 1;
-    cfg.rcRate8 = 90;
     cfg.rcExpo8 = 65;
+#ifndef ALIENWII32
+    cfg.rcRate8 = 90;
     cfg.rollPitchRate = 0;
     cfg.yawRate = 0;
+#else
+    cfg.rcRate8 = 130;
+    cfg.rollPitchRate = 20;
+    cfg.yawRate = 60;
+#endif
     cfg.dynThrPID = 0;
     cfg.tpa_breakpoint = 1500;
     cfg.thrMid8 = 50;
@@ -306,7 +329,11 @@ static void resetConf(void)
     cfg.small_angle = 25;
 
     // Radio
+#ifndef ALIENWII32
     parseRcChannels("AETR1234");
+#else
+    parseRcChannels("TAER1234");
+#endif
     cfg.deadband = 0;
     cfg.yawdeadband = 0;
     cfg.alt_hold_throttle_neutral = 40;

--- a/src/mw.h
+++ b/src/mw.h
@@ -300,6 +300,7 @@ typedef struct master_t {
     // Radio/ESC-related configuration
     uint8_t rcmap[8];                       // mapping of radio channels to internal RPYTA+ order
     uint8_t serialrx_type;                  // type of UART-based receiver (0 = spek 10, 1 = spek 11, 2 = sbus). Must be enabled by FEATURE_SERIALRX first.
+    uint8_t hardware_bind_plug;             // Hardware bind plug support (0 = not present, 1 = present at PB5 pin 41)
     uint8_t spektrum_sat_bind;              // Spektrum satellite bind. 0 - 10 (0 = disabled)
     uint8_t spektrum_sat_on_flexport;       // Spektrum satellite on USART3 (flexport, available with rev5sp hardware)
     uint16_t midrc;                         // Some radios have not a neutral point centered on 1500. can be changed here

--- a/src/spektrum.c
+++ b/src/spektrum.c
@@ -17,8 +17,10 @@ static bool rcFrameComplete = false;
 static bool spekHiRes = false;
 static bool spekDataIncoming = false;
 static GPIO_TypeDef *spekBindPort = NULL;
+static GPIO_TypeDef *hwBindPort = NULL;
 static USART_TypeDef *spekUart = NULL;
 static uint16_t spekBindPin = 0;
+static uint16_t hwBindPin = 0;
 
 volatile uint8_t spekFrame[SPEK_FRAME_SIZE];
 static void spektrumDataReceive(uint16_t c);
@@ -116,8 +118,22 @@ static uint16_t spektrumReadRawRC(uint8_t chan)
 void spektrumBind(void)
 {
     int i;
+    bool bind_active = false;
     gpio_config_t gpio;
 
+    if (mcfg.hardware_bind_plug != 0) {
+	    hwBindPort = GPIOB;
+	    hwBindPin = Pin_5;
+    	gpio.speed = Speed_2MHz;
+	    gpio.pin = hwBindPin;
+	    gpio.mode = Mode_IPU;
+	    gpioInit(hwBindPort, &gpio);
+	    if (digitalIn(hwBindPort, hwBindPin)) {
+	    	bind_active = false;
+	    } else {
+	    	bind_active = true;
+	    }
+    }
     if (mcfg.spektrum_sat_on_flexport) {
         // USART3, PB11
         spekBindPort = GPIOB;
@@ -133,6 +149,9 @@ void spektrumBind(void)
     // don't try to bind if: here after soft reset or bind flag is out of range
     if (rccReadBkpDr() == BKP_SOFTRESET || mcfg.spektrum_sat_bind == 0 || mcfg.spektrum_sat_bind > 10)
         return;
+    // Return if bind plug is is present but not active
+    if (mcfg.hardware_bind_plug != 0 && bind_active == false)
+    	return;
 
     gpio.speed = Speed_2MHz;
     gpio.pin = spekBindPin;
@@ -153,7 +172,8 @@ void spektrumBind(void)
     }
 
     // If we came here as a result of hard  reset (power up, with mcfg.spektrum_sat_bind set), then reset it back to zero and write config
-    if (rccReadBkpDr() != BKP_SOFTRESET) {
+    // Also don't reset if hardware bind plug is present
+    if (rccReadBkpDr() != BKP_SOFTRESET && mcfg.hardware_bind_plug == 0) {
         mcfg.spektrum_sat_bind = 0;
         writeEEPROM(1, true);
     }


### PR DESCRIPTION
default settings for AlienWii32 (8 brushed ESC) based on the NAZE
target.
