### PR TITLE
AlienWii32 alternative defaults for NAZE target

### DIFF
--- a/src/board.h
+++ b/src/board.h
@@ -223,7 +223,13 @@ typedef struct baro_t {
 #define LED0
 #define LED1
 #define INVERTER
+
+// alternative defaults AlienWii32 (activate via OPTIONS="ALIENWII32" during make for NAZE target)
+#ifndef ALIENWII32
 #define MOTOR_PWM_RATE 400
+#else
+#define MOTOR_PWM_RATE 32000
+#endif
 
 #define SENSORS_SET (SENSOR_ACC | SENSOR_BARO | SENSOR_MAG)
 #define I2C_DEVICE (I2CDEV_2)

--- a/src/config.c
+++ b/src/config.c
@@ -218,6 +218,7 @@ static void resetConf(void)
     mcfg.vbatmincellvoltage = 33;
     mcfg.power_adc_channel = 0;
     mcfg.serialrx_type = 0;
+    mcfg.spektrum_sat_bind = 0;
     mcfg.telemetry_provider = TELEMETRY_PROVIDER_FRSKY;
     mcfg.telemetry_port = TELEMETRY_PORT_UART;
     mcfg.telemetry_switch = 0;
@@ -360,6 +361,20 @@ static void resetConf(void)
     // custom mixer. clear by defaults.
     for (i = 0; i < MAX_MOTORS; i++)
         mcfg.customMixer[i].throttle = 0.0f;
+
+    // alternative defaults AlienWii32 (activate via OPTIONS="ALIENWII32" during make for NAZE target)
+#ifdef ALIENWII32
+    featureSet(FEATURE_SERIALRX);
+    featureSet(FEATURE_MOTOR_STOP);
+    mcfg.serialrx_type = 1;
+    mcfg.spektrum_sat_bind = 5;
+    mcfg.minthrottle = 1000;
+    mcfg.maxthrottle = 2000;
+    cfg.rcRate8 = 130;
+    cfg.rollPitchRate = 20;
+    cfg.yawRate = 60;
+    parseRcChannels("TAER1234");
+#endif
 
     // copy default config into all 3 profiles
     for (i = 0; i < 3; i++)


### PR DESCRIPTION
Activate via OPTIONS="ALIENWII32" during make
