### PR TITLE
GPS soft serial support and GPS fixes

### DIFF
--- a/src/cli.c
+++ b/src/cli.c
@@ -160,6 +160,7 @@ const clivalue_t valueTable[] = {
     { "gps_type", VAR_UINT8, &mcfg.gps_type, 0, GPS_HARDWARE_MAX },
     { "gps_baudrate", VAR_INT8, &mcfg.gps_baudrate, 0, GPS_BAUD_MAX },
     { "gps_ubx_sbas", VAR_INT8, &mcfg.gps_ubx_sbas, -1, 4 },
+    { "gps_autobaud", VAR_UINT8, &mcfg.gps_autobaud, 0, 1 },
     { "serialrx_type", VAR_UINT8, &mcfg.serialrx_type, 0, SERIALRX_PROVIDER_MAX },
     { "spektrum_sat_bind", VAR_UINT8, &mcfg.spektrum_sat_bind, 0, 10 },
     { "spektrum_sat_on_flexport", VAR_UINT8, &mcfg.spektrum_sat_on_flexport, 0, 1 },

--- a/src/drv_softserial.c
+++ b/src/drv_softserial.c
@@ -427,9 +427,17 @@ void softSerialWriteByte(serialPort_t *s, uint8_t ch)
 
 void softSerialSetBaudRate(serialPort_t *s, uint32_t baudRate)
 {
-    (void)s;
-    (void)baudRate;
-    // not implemented.
+    uint32_t newbaudRate;
+
+    if (baudRate > SOFT_SERIAL_MAX_BAUD_RATE)
+        newbaudRate = SOFT_SERIAL_MAX_BAUD_RATE;
+    else
+        newbaudRate = baudRate;
+    s->baudRate = newbaudRate;
+
+    // Dummy implementation. Whole soft serial should be redesigned with faster&separate baud rates per port.
+    softSerial_t *softSerial = &(softSerialPorts[0]);
+    setupSoftSerialPrimary(newbaudRate, softSerial->isInverted);
 }
 
 void softSerialSetMode(serialPort_t *instance, portMode_t mode)

--- a/src/drv_softserial.h
+++ b/src/drv_softserial.h
@@ -8,6 +8,8 @@
 #pragma once
 
 #define SOFT_SERIAL_BUFFER_SIZE 256
+// Max baud rate of current soft serial implementation
+#define SOFT_SERIAL_MAX_BAUD_RATE 19200
 
 typedef struct softSerial_s {
     serialPort_t port;

--- a/src/main.c
+++ b/src/main.c
@@ -206,11 +206,9 @@ int main(void)
         }
     }
 #ifndef CJMCU
-    else { // spektrum and GPS are mutually exclusive
-        // Optional GPS - available in both PPM and PWM input mode, in PWM input, reduces number of available channels by 2.
-        // gpsInit will return if FEATURE_GPS is not enabled.
-        gpsInit(mcfg.gps_baudrate);
-    }
+    // Optional GPS - available in both PPM, PWM and serialRX input mode, in PWM input, reduces number of available channels by 2.
+    // gpsInit will return if FEATURE_GPS is not enabled.
+    gpsInit(mcfg.gps_baudrate);
 #endif
 #ifdef SONAR
     // sonar stuff only works with PPM

--- a/src/mw.h
+++ b/src/mw.h
@@ -323,6 +323,8 @@ typedef struct master_t {
     uint8_t gps_type;                       // See GPSHardware enum.
     int8_t gps_baudrate;                    // See GPSBaudRates enum.
     int8_t gps_ubx_sbas;                    // UBX SBAS setting.  -1 = disabled, 0 = AUTO, 1 = EGNOS, 2 = WAAS, 3 = MSAS, 4 = GAGAN (default = 0 = AUTO)
+    uint8_t gps_autobaud;                   // GPS autobaud setting. When enabled GPS baud rate will be lowered if there are timeout. 0 = disabled, 1 = enabled
+
 
     uint32_t serial_baudrate;               // primary serial (MSP) port baudrate
 


### PR DESCRIPTION
Added possibility to use both Serial RX (Spektrum satellite/SBUS/SUMD) and GPS at the same time.
- When features: feature SERIALRX, feature SOFTSERIAL and feature GPS are enabled Serial RX is using UART and pins 3&4 and GPS is using soft serial and pins 5&6.
- Fixed GPS code, so that now it's reconnecting if connection to GPS is lost.
- GPS tab on Chrome Configurator now shows GPS signal strength.
- Added autobauding option. (If connection is lost then it uses lower baudrate.)
