### PR TITLE
GPS debugging info addition

### DIFF
--- a/src/gps.c
+++ b/src/gps.c
@@ -1425,6 +1425,9 @@ static bool UBLOX_parse_gps(void)
         _new_position = true;
         if (!sensors(SENSOR_BARO) && f.FIXED_WING)
             EstAlt = (GPS_altitude - GPS_home[ALT]) * 100;    // Use values Based on GPS
+        // Update GPS update rate table.
+        GPS_update_rate[0] = GPS_update_rate[1];
+        GPS_update_rate[1] = millis();
         break;
     case MSG_STATUS:
         next_fix = (_buffer.status.fix_status & NAV_STATUS_FIX_VALID) && (_buffer.status.fix_type == FIX_3D);

--- a/src/mw.c
+++ b/src/mw.c
@@ -61,6 +61,7 @@ uint8_t GPS_svinfo_chn[16];         // Channel number
 uint8_t GPS_svinfo_svid[16];        // Satellite ID
 uint8_t GPS_svinfo_quality[16];     // Bitfield Qualtity
 uint8_t GPS_svinfo_cno[16];         // Carrier to Noise Ratio (Signal Strength)
+uint32_t GPS_update_rate[2];        // GPS coordinates updating rate (column 0 = last update time, 1 = current update ms)
 
 // Automatic ACC Offset Calibration
 bool AccInflightCalibrationArmed = false;

--- a/src/mw.h
+++ b/src/mw.h
@@ -498,6 +498,7 @@ extern uint8_t  GPS_svinfo_chn[16];                          // Channel number
 extern uint8_t  GPS_svinfo_svid[16];                         // Satellite ID
 extern uint8_t  GPS_svinfo_quality[16];                      // Bitfield Qualtity
 extern uint8_t  GPS_svinfo_cno[16];                          // Carrier to Noise Ratio (Signal Strength)
+extern uint32_t GPS_update_rate[2];                          // GPS coordinates updating rate
 extern core_t core;
 extern master_t mcfg;
 extern config_t cfg;

--- a/src/serial.c
+++ b/src/serial.c
@@ -68,6 +68,7 @@
 #define MSP_ACC_TRIM             240    //out message         get acc angle trim values
 #define MSP_SET_ACC_TRIM         239    //in message          set acc angle trim values
 #define MSP_GPSSVINFO            164    //out message         get Signal Strength (only U-Blox)
+#define MSP_GPSDEBUGINFO         166    //out message         get GPS debugging data (only U-Blox)
 
 // Additional private MSP for baseflight configurator
 #define MSP_RCMAP                64     //out message         get channel map (also returns number of channels total)
@@ -846,6 +847,16 @@ static void evaluateCommand(void)
                serialize8(GPS_svinfo_cno[i]);
             }
         break;
+#ifdef GPS
+    case MSP_GPSDEBUGINFO:
+        headSerialReply(5);
+        if (sensors(SENSOR_GPS))
+            serialize32(GPS_update_rate[1] - GPS_update_rate[0]);
+        else
+            serialize32(0);
+        serialize8(rcOptions[BOXGPSHOLD]);
+        break;
+#endif /* GPS */
 
     case MSP_SET_CONFIG:
         headSerialReply(0);


### PR DESCRIPTION
Added new GPS debug info which can be used on configurator:
- Check GPS HW location update rate (is it really 5hz or something else)
- Test GPS HW accuracy (activating gps hold while on the ground PC configurator will start calculating GPS location drifting)