### PR TITLE
GPS UBX-NAV-SVINFO fixes

### DIFF
--- a/src/drv_softserial.h
+++ b/src/drv_softserial.h
@@ -9,7 +9,7 @@
 
 #define SOFT_SERIAL_BUFFER_SIZE 256
 // Max baud rate of current soft serial implementation
-#define SOFT_SERIAL_MAX_BAUD_RATE 19200
+#define SOFT_SERIAL_MAX_BAUD_RATE 38400
 
 typedef struct softSerial_s {
     serialPort_t port;

--- a/src/mw.c
+++ b/src/mw.c
@@ -57,11 +57,12 @@ int16_t nav[2];
 int16_t nav_rated[2];               // Adding a rate controller to the navigation to make it smoother
 int8_t nav_mode = NAV_MODE_NONE;    // Navigation mode
 uint8_t GPS_numCh;                  // Number of channels
-uint8_t GPS_svinfo_chn[16];         // Channel number
-uint8_t GPS_svinfo_svid[16];        // Satellite ID
-uint8_t GPS_svinfo_quality[16];     // Bitfield Qualtity
-uint8_t GPS_svinfo_cno[16];         // Carrier to Noise Ratio (Signal Strength)
+uint8_t GPS_svinfo_chn[32];         // Channel number
+uint8_t GPS_svinfo_svid[32];        // Satellite ID
+uint8_t GPS_svinfo_quality[32];     // Bitfield Qualtity
+uint8_t GPS_svinfo_cno[32];         // Carrier to Noise Ratio (Signal Strength)
 uint32_t GPS_update_rate[2];        // GPS coordinates updating rate (column 0 = last update time, 1 = current update ms)
+uint32_t GPS_svinfo_rate[2];        // GPS svinfo updating rate (column 0 = last update time, 1 = current update ms)
 
 // Automatic ACC Offset Calibration
 bool AccInflightCalibrationArmed = false;

--- a/src/mw.h
+++ b/src/mw.h
@@ -494,11 +494,12 @@ extern int16_t  nav[2];
 extern int8_t   nav_mode;                                    // Navigation mode
 extern int16_t  nav_rated[2];                                // Adding a rate controller to the navigation to make it smoother
 extern uint8_t  GPS_numCh;                                   // Number of channels
-extern uint8_t  GPS_svinfo_chn[16];                          // Channel number
-extern uint8_t  GPS_svinfo_svid[16];                         // Satellite ID
-extern uint8_t  GPS_svinfo_quality[16];                      // Bitfield Qualtity
-extern uint8_t  GPS_svinfo_cno[16];                          // Carrier to Noise Ratio (Signal Strength)
+extern uint8_t  GPS_svinfo_chn[32];                          // Channel number
+extern uint8_t  GPS_svinfo_svid[32];                         // Satellite ID
+extern uint8_t  GPS_svinfo_quality[32];                      // Bitfield Qualtity
+extern uint8_t  GPS_svinfo_cno[32];                          // Carrier to Noise Ratio (Signal Strength)
 extern uint32_t GPS_update_rate[2];                          // GPS coordinates updating rate
+extern uint32_t GPS_svinfo_rate[2];                          // GPS svinfo updating rate
 extern core_t core;
 extern master_t mcfg;
 extern config_t cfg;
@@ -597,6 +598,7 @@ void gpsInit(uint8_t baudrate);
 void gpsThread(void);
 void gpsSetPIDs(void);
 int8_t gpsSetPassthrough(void);
+void gpsPollSvinfo(void);
 void GPS_reset_home_position(void);
 void GPS_reset_nav(void);
 void GPS_set_next_wp(int32_t* lat, int32_t* lon);

--- a/src/serial.c
+++ b/src/serial.c
@@ -840,21 +840,25 @@ static void evaluateCommand(void)
     case MSP_GPSSVINFO:
         headSerialReply(1 + (GPS_numCh * 4));
         serialize8(GPS_numCh);
-           for (i = 0; i < GPS_numCh; i++){
-               serialize8(GPS_svinfo_chn[i]);
-               serialize8(GPS_svinfo_svid[i]);
-               serialize8(GPS_svinfo_quality[i]);
-               serialize8(GPS_svinfo_cno[i]);
-            }
+        for (i = 0; i < GPS_numCh; i++){
+            serialize8(GPS_svinfo_chn[i]);
+            serialize8(GPS_svinfo_svid[i]);
+            serialize8(GPS_svinfo_quality[i]);
+            serialize8(GPS_svinfo_cno[i]);
+        }
+        // Poll new SVINFO from GPS
+        gpsPollSvinfo();
         break;
 #ifdef GPS
     case MSP_GPSDEBUGINFO:
-        headSerialReply(5);
-        if (sensors(SENSOR_GPS))
+        headSerialReply(8);
+        if (sensors(SENSOR_GPS)) {
             serialize32(GPS_update_rate[1] - GPS_update_rate[0]);
-        else
+            serialize32(GPS_svinfo_rate[1] - GPS_svinfo_rate[0]);
+        } else {
             serialize32(0);
-        serialize8(rcOptions[BOXGPSHOLD]);
+            serialize32(0);
+        }
         break;
 #endif /* GPS */
 


### PR DESCRIPTION
- New GPS HW can find more satellites (e.g. Ublox M8 series) than old ones. So increased buffer size because SVINFO message sizes has been also increased.
- Increased svinfo-array sizes so that configurator get all the data and then can sort it so that best quality satellite data is shown.
- SVINFO is now coming only when polled by configurator. This decreases board load when flying.
- Added new SVINFO rate debug message for configurator gps tab.
- Increased soft serial GPS speed to 38400.