### PR TITLE
Few updates for the MSP serial command for flying wings

### DIFF
--- a/src/cli.c
+++ b/src/cli.c
@@ -272,7 +272,7 @@ const clivalue_t valueTable[] = {
     { "fw_idle_throttle", VAR_UINT16, &cfg.fw_idle_throttle, 1000, 2000 },
     { "fw_scaler_throttle", VAR_UINT16, &cfg.fw_scaler_throttle, 0, 15 },
     { "fw_roll_comp", VAR_FLOAT, &cfg.fw_roll_comp, 0, 2 },
-    { "fw_rth_alt", VAR_UINT8, &cfg.D8[PIDPOSR], 0, 200 },
+    { "fw_rth_alt", VAR_UINT8, &cfg.fw_rth_alt, 0, 200 },
 };
 
 #define VALUE_COUNT (sizeof(valueTable) / sizeof(clivalue_t))

--- a/src/fw_nav.c
+++ b/src/fw_nav.c
@@ -45,7 +45,7 @@ void fw_nav(void)
     int16_t GPS_Heading = GPS_ground_course;    // Store current bearing
     int16_t Current_Heading;                    // Store current bearing
     int16_t altDiff = 0;
-    int8_t RTH_Alt = cfg.fw_rth_alt;           // Min Altitude to keep during RTH. (Max 200m)
+    uint8_t RTH_Alt = cfg.fw_rth_alt;           // Min Altitude to keep during RTH. (Max 200m)
     int16_t delta[2] = { 0, 0 };                // D-Term
     static int16_t NAV_deltaSum, ALT_deltaSum, GPS_FwTarget, GPS_AltErr, NAV_Thro;
     int16_t TX_Thro = rcData[THROTTLE];         // Read and store Throttle pos.

--- a/src/fw_nav.c
+++ b/src/fw_nav.c
@@ -45,7 +45,7 @@ void fw_nav(void)
     int16_t GPS_Heading = GPS_ground_course;    // Store current bearing
     int16_t Current_Heading;                    // Store current bearing
     int16_t altDiff = 0;
-    int16_t RTH_Alt = cfg.D8[PIDPOSR];          // conf.pid[PIDALT].D8;
+    int8_t RTH_Alt = cfg.fw_rth_alt;           // Min Altitude to keep during RTH. (Max 200m)
     int16_t delta[2] = { 0, 0 };                // D-Term
     static int16_t NAV_deltaSum, ALT_deltaSum, GPS_FwTarget, GPS_AltErr, NAV_Thro;
     int16_t TX_Thro = rcData[THROTTLE];         // Read and store Throttle pos.

--- a/src/mw.h
+++ b/src/mw.h
@@ -293,6 +293,7 @@ typedef struct config_t {
     uint16_t fw_idle_throttle;                 // Lowest throttleValue during Descend
     uint16_t fw_scaler_throttle;               // Adjust to Match Power/Weight ratio of your model
     float fw_roll_comp;
+    uint8_t fw_rth_alt;                        // Min Altitude to keep during RTH. (Max 200m)
 
 } config_t;
 

--- a/src/serial.c
+++ b/src/serial.c
@@ -543,7 +543,7 @@ static void evaluateCommand(void)
             serialize16(cfg.fw_idle_throttle);
             serialize16(cfg.fw_scaler_throttle);
             serialize32(cfg.fw_roll_comp);
-            serialize8(cfg.D8[PIDPOSR]);
+            serialize8(cfg.fw_rth_alt);
             // next added for future use
             serialize32(0);
             serialize32(0);
@@ -565,7 +565,7 @@ static void evaluateCommand(void)
             cfg.fw_idle_throttle = read16();
             cfg.fw_scaler_throttle = read16();
             cfg.fw_roll_comp = read32();
-            cfg.D8[PIDPOSR] = read8();
+            cfg.fw_rth_alt = read8();
             // next added for future use
             read32();
             read32();

--- a/src/serial.c
+++ b/src/serial.c
@@ -529,7 +529,7 @@ static void evaluateCommand(void)
             loadCustomServoMixer();
             break;
         case MSP_FW_CONFIG:
-            headSerialReply(31);
+            headSerialReply(47);
             serialize8(mcfg.fw_althold_dir);
             serialize32(cfg.fw_roll_throw);
             serialize32(cfg.fw_pitch_throw);


### PR DESCRIPTION
Few fixes and code changes:
- Updated MSP packet size to include extra reserved spaces
- Moved the fw_rth_alt param to use it's own config variable rather than getting the values form POSR
- Changed data type to uint8_t in fw_nav.c for RTH_Alt, values range from 0 to 200 so its enough