### PR TITLE
expose small_angle and looptime variables through MSP

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -294,6 +294,7 @@ static void resetConf(void)
     //     cfg.activate[i] = 0;
     cfg.angleTrim[0] = 0;
     cfg.angleTrim[1] = 0;
+    cfg.locked_in = 0;
     cfg.mag_declination = 0;    // For example, -6deg 37min, = -637 Japan, format is [sign]dddmm (degreesminutes) default is zero.
     cfg.acc_lpf_factor = 4;
     cfg.accz_deadband = 40;

--- a/src/mw.h
+++ b/src/mw.h
@@ -232,6 +232,7 @@ typedef struct config_t {
     uint16_t tpa_breakpoint;                // Breakpoint where TPA is activated
     int16_t mag_declination;                // Get your magnetic decliniation from here : http://magnetic-declination.com/
     int16_t angleTrim[2];                   // accelerometer trim
+    uint8_t locked_in;
 
     // sensor-related stuff
     uint8_t acc_lpf_factor;                 // Set the Low Pass Filter factor for ACC. Increasing this value would reduce ACC noise (visible in GUI), but would increase ACC lag time. Zero = no filter

--- a/src/serial.c
+++ b/src/serial.c
@@ -815,10 +815,11 @@ static void evaluateCommand(void)
             mcfg.power_adc_channel = read8();
             cfg.small_angle = read8();
             mcfg.looptime = read16();
+            cfg.locked_in = read8();
             /// ???
             break;
         case MSP_CONFIG:
-            headSerialReply(1 + 4 + 1 + 2 + 2 + 2 + 2 + 2 + 2 + 2 + 1 + 1 + 2);
+            headSerialReply(1 + 4 + 1 + 2 + 2 + 2 + 2 + 2 + 2 + 2 + 1 + 1 + 2 + 1);
             serialize8(mcfg.mixerConfiguration);
             serialize32(featureMask());
             serialize8(mcfg.serialrx_type);
@@ -833,6 +834,7 @@ static void evaluateCommand(void)
             serialize8(mcfg.power_adc_channel);
             serialize8(cfg.small_angle);
             serialize16(mcfg.looptime);
+            serialize8(cfg.locked_in);
             /// ???
             break;
 

--- a/src/serial.c
+++ b/src/serial.c
@@ -813,10 +813,12 @@ static void evaluateCommand(void)
             cfg.rollPitchRate[0] = read8();
             cfg.rollPitchRate[1] = read8();
             mcfg.power_adc_channel = read8();
+            cfg.small_angle = read8();
+            mcfg.looptime = read16();
             /// ???
             break;
         case MSP_CONFIG:
-            headSerialReply(1 + 4 + 1 + 2 + 2 + 2 + 2 + 2 + 2 + 2 + 1);
+            headSerialReply(1 + 4 + 1 + 2 + 2 + 2 + 2 + 2 + 2 + 2 + 1 + 1 + 2);
             serialize8(mcfg.mixerConfiguration);
             serialize32(featureMask());
             serialize8(mcfg.serialrx_type);
@@ -829,6 +831,8 @@ static void evaluateCommand(void)
             serialize8(cfg.rollPitchRate[0]);
             serialize8(cfg.rollPitchRate[1]);
             serialize8(mcfg.power_adc_channel);
+            serialize8(cfg.small_angle);
+            serialize16(mcfg.looptime);
             /// ???
             break;
 


### PR DESCRIPTION
since some users requested this and we are already bumping the msp_version for next release, seems like a logical choice to squeeze some more stuff in.

I dont have a dev environment on my machine so let the bot test this before merging