### PR TITLE
Buzzer mute option.

### DIFF
--- a/src/buzzer.c
+++ b/src/buzzer.c
@@ -81,6 +81,8 @@ void buzzer(uint8_t mode)
 {
     uint8_t i = 0;
 
+    if (mcfg.buzzer_mute)
+        return;
     // Just return if same or higher priority sound is active.
     if (buzzerMode <= mode)
         return;

--- a/src/cli.c
+++ b/src/cli.c
@@ -212,6 +212,7 @@ const clivalue_t valueTable[] = {
     { "rssi_adc_channel", VAR_INT8, &mcfg.rssi_adc_channel, 0, 9 },
     { "rssi_adc_max", VAR_INT16, &mcfg.rssi_adc_max, 1, 4095 },
     { "rssi_adc_offset", VAR_INT16, &mcfg.rssi_adc_offset, 0, 4095 },
+    { "buzzer_mute", VAR_INT8, &mcfg.buzzer_mute, 0, 1 },
     { "yaw_direction", VAR_INT8, &cfg.yaw_direction, -1, 1 },
     { "tri_unarmed_servo", VAR_INT8, &cfg.tri_unarmed_servo, 0, 1 },
     { "gimbal_flags", VAR_UINT8, &cfg.gimbal_flags, 0, 255},

--- a/src/mw.h
+++ b/src/mw.h
@@ -366,6 +366,7 @@ typedef struct master_t {
     uint8_t rssi_adc_channel;               // Read analog-rssi from RC-filter (RSSI-PWM to RSSI-Analog), RC_CH2 (unused when in CPPM mode, = 1), RC_CH8 (last channel in PWM mode, = 9), ADC_EXTERNAL_PAD (Rev5 only, = 5), 0 to disable (disabled if rssi_aux_channel > 0 or rssi_adc_channel == power_adc_channel)
     uint16_t rssi_adc_max;                  // max input voltage defined by RC-filter (is RSSI never 100% reduce the value) (1...4095)
     uint16_t rssi_adc_offset;               // input offset defined by RC-filter (0...4095)
+    uint8_t buzzer_mute;                    // buzzer is only activated when BOXITEM is selected
 
     // gps-related stuff
     uint8_t gps_type;                       // See GPSHardware enum.


### PR DESCRIPTION
Buzzer can only be activated if BOXITEM is selected and enabled.