### PR TITLE
Make servoMixer work for types other than CUSTOM_PLANE

### DIFF
--- a/src/board.h
+++ b/src/board.h
@@ -99,6 +99,7 @@ typedef enum {
     FEATURE_FW_FAILSAFE_RTH = 1 << 15,
     FEATURE_SYNCPWM = 1 << 16,
     FEATURE_FASTPWM = 1 << 17,
+    FEATURE_SERVO_MIXER = 1 << 18,
 } AvailableFeatures;
 
 typedef enum {

--- a/src/cli.c
+++ b/src/cli.c
@@ -64,7 +64,7 @@ static const char *const featureNames[] = {
     "PPM", "VBAT", "INFLIGHT_ACC_CAL", "SERIALRX", "MOTOR_STOP",
     "SERVO_TILT", "SOFTSERIAL", "LED_RING", "GPS",
     "FAILSAFE", "SONAR", "TELEMETRY", "POWERMETER", "VARIO", "3D",
-    "FW_FAILSAFE_RTH", "SYNCPWM", "FASTPWM",
+    "FW_FAILSAFE_RTH", "SYNCPWM", "FASTPWM", "SERVO_MIXER",
     NULL
 };
 

--- a/src/mixer.c
+++ b/src/mixer.c
@@ -474,9 +474,11 @@ void writeAllMotors(int16_t mc)
     writeMotors();
 }
 
-static void resetServos(void) {
+static void resetServos(void)
+{
+    int i;
+
     // reset all servos to their middle value
-    uint8_t i;
     for (i = 0; i < MAX_SERVOS; i++)
         servo[i] = servoMiddle(i);
 }
@@ -529,8 +531,7 @@ static void servoMixer(void)
             if (currentServoMixer[i].speed == 0) {
                 // directly use the input value if speed is not provided
                 currentOutput[i] = input[from];
-            }
-            else {
+            } else {
                 // apply speed constraints
                 if (currentOutput[i] < input[from])
                     currentOutput[i] = constrain(currentOutput[i] + currentServoMixer[i].speed, currentOutput[i], input[from]);
@@ -539,7 +540,7 @@ static void servoMixer(void)
             }
 
             // start with the output value
-            servo[target] = (int32_t)currentOutput[i];
+            servo[target] = (int16_t)currentOutput[i];
 
             // apply rate from mixer rule
             servo[target] *= ((float)currentServoMixer[i].rate / 100);
@@ -581,10 +582,9 @@ void mixTable(void)
             motor[0] = constrain(rcCommand[THROTTLE], mcfg.minthrottle, mcfg.maxthrottle);
     }
 
-    if (core.useServo == 1) {
-        // reset all servos
+    // reset all servos
+    if (core.useServo)
         resetServos();
-    }
 
     if (mcfg.mixerConfiguration == MULTITYPE_GIMBAL) {
         // set servo output for gimbal type
@@ -606,10 +606,9 @@ void mixTable(void)
         }
     }
 
-    if (core.useServo == 1) {
-        // run the servo mixer if necessary
+    // run the servo mixer if necessary
+    if (core.useServo)
         servoMixer();
-    }
 
     // constrain servos
     for (i = 0; i < MAX_SERVOS; i++)

--- a/src/mixer.c
+++ b/src/mixer.c
@@ -380,6 +380,16 @@ void writeServos(void)
     if (!core.useServo)
         return;
 
+    // forward AUX1-4 to servo outputs (not constrained)
+    if (cfg.gimbal_flags & GIMBAL_FORWARDAUX) {
+        int offset = core.numServos - 4;
+        // offset servos based off number already used in mixer types
+        // airplane and servo_tilt together can't be used
+        // calculate offset by taking 4 from core.numServos
+        for (i = 0; i < 4; i++)
+            pwmWriteServo(i + offset, rcData[AUX1 + i]);
+    }
+
     // apply servos for the specific mixerConfiguration
     switch (mcfg.mixerConfiguration) {
         case MULTITYPE_BI:
@@ -604,16 +614,6 @@ void mixTable(void)
     // constrain servos
     for (i = 0; i < MAX_SERVOS; i++)
         servo[i] = constrain(servo[i], cfg.servoConf[i].min, cfg.servoConf[i].max); // limit the values
-
-    // forward AUX1-4 to servo outputs (not constrained)
-    if (cfg.gimbal_flags & GIMBAL_FORWARDAUX) {
-        int offset = core.numServos - 4;
-        // offset servos based off number already used in mixer types
-        // airplane and servo_tilt together can't be used
-        // calculate offset by taking 4 from core.numServos
-        for (i = 0; i < 4; i++)
-            pwmWriteServo(i + offset, rcData[AUX1 + i]);
-    }
 
     maxMotor = motor[0];
     for (i = 1; i < numberMotor; i++)


### PR DESCRIPTION
### Motivation

I wanted to use the servo mixer to assign a certain switch to control a servo on a certain ESC header on my quadcopter.

This change lets you enable the servo mixer for and create rules to do just that.

### Usage: Control servos on a QUADX

```
# Be a QUADX
mixer QUADX
 
# Enable servo mixer
feature SERVO_MIXER
 
# Reset servo mixer
smix reset
 
# Control servo output 1 with channel 7 (AUX_3)
smix 1 1 7 100 0 0 100 0
 
# Control servo output 2 with channel 8 (AUX_4)
smix 1 2 8 100 0 0 100 0
```

The wiring is as follows:

Header 1: Servo 1
Header 2: Servo 2
Header 3: Motor 1
Header 4: Motor 2
Header 5: Motor 3
Header 6: Motor 4

### Changes

* Added SERVO_MIXER feature to enable the servo mixer regardless of craft type
* Reset servos before applying servo values due to SERVO_TILT feature or GIMBAL type
* Servo mixer rules can override values set by SERVO_TILT feature and GIMBAL type
* Only apply rates to servo values affected by servo mixer rules
* Apply servo values to channels 1 and 2 when SERVO_MIXER feature is enabled
* Fix bug where input values in servoMixer were reversed due to subtracting the RC value from the RC middle value
* Center all servos by default
* Do gimbal AUX forwarding inside of writeServos()

## When is servo mixer enabled?

Assuming you've set `feature SERVOMIXER`, the servo mixer is enabled as follows, based on your type:

###  Servo mixer is enabled and works as it currently does, but only on the servos that are already used by this multitype

* MULTITYPE_CUSTOM_PLANE
* MULTITYPE_FLYING_WING
* MULTITYPE_AIRPLANE
* MULTITYPE_BI
* MULTITYPE_TRI
* MULTITYPE_DUALCOPTER
* MULTITYPE_SINGLECOPTER
* MULTITYPE_GIMBAL

### Servo mixer works for servos 1 and 2

* MULTITYPE_GIMBAL
* MULTITYPE_QUADP
* MULTITYPE_QUADX
* MULTITYPE_GIMBAL
* MULTITYPE_Y6
* MULTITYPE_HEX6
* MULTITYPE_Y4
* MULTITYPE_HEX6X
* MULTITYPE_OCTOX8
* MULTITYPE_OCTOFLATP
* MULTITYPE_OCTOFLATX
* MULTITYPE_HELI_120_CCPM
* MULTITYPE_HELI_90_DEG
* MULTITYPE_VTAIL4
* MULTITYPE_HEX6H
* MULTITYPE_PPM_TO_SERVO
* MULTITYPE_ATAIL4
* MULTITYPE_CUSTOM
* MULTITYPE_CUSTOM_PLANE