### PR TITLE
Make: Change debug optimisation level to fit within flash size

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -138,7 +138,7 @@ INCLUDE_DIRS	 = $(SRC_DIR) \
 ARCH_FLAGS	 = -mthumb -mcpu=cortex-m3
 
 ifeq ($(DEBUG),GDB)
-OPTIMIZE	 = -O0
+OPTIMIZE	 = -Og
 LTO_FLAGS	 = $(OPTIMIZE)
 else
 OPTIMIZE	 = -Os


### PR DESCRIPTION
Advantages:
- drops debug build flash size to ~91k (from ~126k, almost overflowing)
- only enables optimizations that don't interfere with debugging [1]

Disadvantages:
- no longer supports GCC < 4.8 (released end of 2013)

[1] https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#index-Ofast-903
> -Og
>Optimize debugging experience. -Og enables optimizations that do not interfere with debugging. It should be the optimization level of choice for the standard edit-compile-debug cycle, offering a reasonable level of optimization while maintaining fast compilation and a good debugging experience.