### PR TITLE
add 'rssi_aux_max' cli param

### DIFF
--- a/src/cli.c
+++ b/src/cli.c
@@ -209,6 +209,7 @@ const clivalue_t valueTable[] = {
     { "failsafe_detect_threshold", VAR_UINT16, &cfg.failsafe_detect_threshold, 100, 2000 },
     { "auto_disarm_board", VAR_UINT8, &mcfg.auto_disarm_board, 0, 60 },
     { "rssi_aux_channel", VAR_INT8, &mcfg.rssi_aux_channel, 0, 4 },
+    { "rssi_aux_max", VAR_UINT16, &mcfg.rssi_aux_max, 0, 1000 },
     { "rssi_adc_channel", VAR_INT8, &mcfg.rssi_adc_channel, 0, 9 },
     { "rssi_adc_max", VAR_INT16, &mcfg.rssi_adc_max, 1, 4095 },
     { "rssi_adc_offset", VAR_INT16, &mcfg.rssi_adc_offset, 0, 4095 },

--- a/src/config.c
+++ b/src/config.c
@@ -252,6 +252,7 @@ static void resetConf(void)
     mcfg.looptime = 3500;
     mcfg.emf_avoidance = 0;
     mcfg.rssi_aux_channel = 0;
+    mcfg.rssi_aux_max = 1000;
     mcfg.rssi_adc_max = 4095;
 
     cfg.pidController = 0;

--- a/src/mw.h
+++ b/src/mw.h
@@ -363,7 +363,7 @@ typedef struct master_t {
     uint8_t disarm_kill_switch;             // AUX disarm independently of throttle value
     int8_t fw_althold_dir;                  // +1 or -1 for pitch/althold gain. later check if need more than just sign
     uint8_t rssi_aux_channel;               // Read rssi from channel. 1+ = AUX1+, 0 to disable.
-    uint16_t rssi_aux_max;                  // max value for injected RSSI on AUX channel, range (0...1000), default is 1000  
+    uint16_t rssi_aux_max;                  // max value for injected RSSI on AUX channel, range (0...1000), default is 1000
     uint8_t rssi_adc_channel;               // Read analog-rssi from RC-filter (RSSI-PWM to RSSI-Analog), RC_CH2 (unused when in CPPM mode, = 1), RC_CH8 (last channel in PWM mode, = 9), ADC_EXTERNAL_PAD (Rev5 only, = 5), 0 to disable (disabled if rssi_aux_channel > 0 or rssi_adc_channel == power_adc_channel)
     uint16_t rssi_adc_max;                  // max input voltage defined by RC-filter (is RSSI never 100% reduce the value) (1...4095)
     uint16_t rssi_adc_offset;               // input offset defined by RC-filter (0...4095)

--- a/src/mw.h
+++ b/src/mw.h
@@ -363,6 +363,7 @@ typedef struct master_t {
     uint8_t disarm_kill_switch;             // AUX disarm independently of throttle value
     int8_t fw_althold_dir;                  // +1 or -1 for pitch/althold gain. later check if need more than just sign
     uint8_t rssi_aux_channel;               // Read rssi from channel. 1+ = AUX1+, 0 to disable.
+    uint16_t rssi_aux_max;                  // max value for injected RSSI on AUX channel, range (0...1000), default is 1000  
     uint8_t rssi_adc_channel;               // Read analog-rssi from RC-filter (RSSI-PWM to RSSI-Analog), RC_CH2 (unused when in CPPM mode, = 1), RC_CH8 (last channel in PWM mode, = 9), ADC_EXTERNAL_PAD (Rev5 only, = 5), 0 to disable (disabled if rssi_aux_channel > 0 or rssi_adc_channel == power_adc_channel)
     uint16_t rssi_adc_max;                  // max input voltage defined by RC-filter (is RSSI never 100% reduce the value) (1...4095)
     uint16_t rssi_adc_offset;               // input offset defined by RC-filter (0...4095)

--- a/src/sensors.c
+++ b/src/sensors.c
@@ -193,7 +193,7 @@ uint16_t RSSI_getValue(void)
     if (mcfg.rssi_aux_channel > 0) {
         const int16_t rssiChannelData = rcData[AUX1 + mcfg.rssi_aux_channel - 1];
         // Range of rssiChannelData is [1000;2000]. rssi should be in [0;1023];
-        value = (uint16_t)((constrain(rssiChannelData - 1000, 0, 1000) / 1000.0f) * 1023.0f);
+        value = (uint16_t)((constrain(rssiChannelData - 1000, 0, mcfg.rssi_aux_max) / (float) mcfg.rssi_aux_max) * 1023.0f);
     } else if (mcfg.rssi_adc_channel > 0) {
         const int16_t rssiData = (((int32_t)(adcGetChannel(ADC_RSSI) - mcfg.rssi_adc_offset)) * 1023L) / mcfg.rssi_adc_max;
         // Set to correct range [0;1023]


### PR DESCRIPTION
User-configurable max value for RSSI injection on AUX channel. Useful for adjusting the upper bound of the RSSI range in order to fine-tune the calculated RSSI percentage.