### PR TITLE
adjustable RC & AUX channel counts, increased rssi_aux_channel limit

### DIFF
--- a/src/cli.c
+++ b/src/cli.c
@@ -208,11 +208,12 @@ const clivalue_t valueTable[] = {
     { "failsafe_throttle", VAR_UINT16, &cfg.failsafe_throttle, 1000, 2000 },
     { "failsafe_detect_threshold", VAR_UINT16, &cfg.failsafe_detect_threshold, 100, 2000 },
     { "auto_disarm_board", VAR_UINT8, &mcfg.auto_disarm_board, 0, 60 },
-    { "rssi_aux_channel", VAR_INT8, &mcfg.rssi_aux_channel, 0, 4 },
+    { "rssi_aux_channel", VAR_INT8, &mcfg.rssi_aux_channel, 0, 14 },
     { "rssi_aux_max", VAR_UINT16, &mcfg.rssi_aux_max, 0, 1000 },
     { "rssi_adc_channel", VAR_INT8, &mcfg.rssi_adc_channel, 0, 9 },
     { "rssi_adc_max", VAR_INT16, &mcfg.rssi_adc_max, 1, 4095 },
     { "rssi_adc_offset", VAR_INT16, &mcfg.rssi_adc_offset, 0, 4095 },
+    { "rc_channel_count", VAR_UINT8, &mcfg.rc_channel_count, 8, 18 },
     { "yaw_direction", VAR_INT8, &cfg.yaw_direction, -1, 1 },
     { "tri_unarmed_servo", VAR_INT8, &cfg.tri_unarmed_servo, 0, 1 },
     { "gimbal_flags", VAR_UINT8, &cfg.gimbal_flags, 0, 255},
@@ -879,7 +880,7 @@ static void cliDump(char *cmdline)
     }
 
     // print RC MAPPING
-    for (i = 0; i < 8; i++)
+    for (i = 0; i < mcfg.rc_channel_count; i++)
         buf[mcfg.rcmap[i]] = rcChannelLetters[i];
     buf[i] = '\0';
     printf("map %s\r\n", buf);
@@ -991,11 +992,11 @@ static void cliMap(char *cmdline)
 
     len = strlen(cmdline);
 
-    if (len == 8) {
+    if (len == mcfg.rc_channel_count) {
         // uppercase it
-        for (i = 0; i < 8; i++)
+        for (i = 0; i < mcfg.rc_channel_count; i++)
             cmdline[i] = toupper((unsigned char)cmdline[i]);
-        for (i = 0; i < 8; i++) {
+        for (i = 0; i < mcfg.rc_channel_count; i++) {
             if (strchr(rcChannelLetters, cmdline[i]) && !strchr(cmdline + i + 1, cmdline[i]))
                 continue;
             cliPrint("Must be any order of AETR1234\r\n");
@@ -1004,7 +1005,7 @@ static void cliMap(char *cmdline)
         parseRcChannels(cmdline);
     }
     cliPrint("Current assignment: ");
-    for (i = 0; i < 8; i++)
+    for (i = 0; i < mcfg.rc_channel_count; i++)
         out[mcfg.rcmap[i]] = rcChannelLetters[i];
     out[i] = '\0';
     printf("%s\r\n", out);

--- a/src/config.c
+++ b/src/config.c
@@ -22,7 +22,7 @@
 
 master_t mcfg;  // master config struct with data independent from profiles
 config_t cfg;   // profile config struct
-const char rcChannelLetters[] = "AERT1234";
+const char rcChannelLetters[] = "AERT123456789LMNOP";  // hack for the char-based channel mapping stuff, 18 channels hard max
 
 static const uint8_t EEPROM_CONF_VERSION = 75;
 static uint32_t enabledSensors = 0;
@@ -254,6 +254,7 @@ static void resetConf(void)
     mcfg.rssi_aux_channel = 0;
     mcfg.rssi_aux_max = 1000;
     mcfg.rssi_adc_max = 4095;
+    mcfg.rc_channel_count = 8;
 
     cfg.pidController = 0;
     cfg.P8[ROLL] = 40;
@@ -309,7 +310,7 @@ static void resetConf(void)
     cfg.small_angle = 25;
 
     // Radio
-    parseRcChannels("AETR1234");
+    parseRcChannels( "AETR123456789LMNOP" );    //18 channels max
     cfg.deadband = 0;
     cfg.yawdeadband = 0;
     cfg.alt_hold_throttle_neutral = 40;

--- a/src/drv_pwm.c
+++ b/src/drv_pwm.c
@@ -60,7 +60,7 @@ enum {
 typedef void (*pwmWriteFuncPtr)(uint8_t index, uint16_t value);  // function pointer used to write motors
 
 static pwmPortData_t pwmPorts[MAX_PORTS];
-static uint16_t captures[MAX_INPUTS];
+static uint16_t captures[MAX_PPM_INPUTS];    // max out the captures array, just in case...
 static pwmPortData_t *motors[MAX_MOTORS];
 static pwmPortData_t *servos[MAX_SERVOS];
 static pwmWriteFuncPtr pwmWritePtr = NULL;
@@ -315,7 +315,7 @@ static void ppmCallback(uint8_t port, uint16_t capture)
     if (diff > 2700) { // Per http://www.rcgroups.com/forums/showpost.php?p=21996147&postcount=3960 "So, if you use 2.5ms or higher as being the reset for the PPM stream start, you will be fine. I use 2.7ms just to be safe."
         chan = 0;
     } else {
-        if (diff > PULSE_MIN && diff < PULSE_MAX && chan < MAX_INPUTS) {   // 750 to 2250 ms is our 'valid' channel range
+        if (diff > PULSE_MIN && diff < PULSE_MAX && chan < MAX_PPM_INPUTS) {   // 750 to 2250 ms is our 'valid' channel range
             captures[chan] = diff;
             failsafeCheck(chan, diff);
         }

--- a/src/drv_pwm.h
+++ b/src/drv_pwm.h
@@ -6,7 +6,8 @@
 
 #define MAX_MOTORS  12
 #define MAX_SERVOS  8
-#define MAX_INPUTS  8
+#define MAX_PWM_INPUTS  8
+#define MAX_PPM_INPUTS 16
 #define PULSE_1MS   (1000)      // 1ms pulse width
 #define PULSE_MIN   (750)       // minimum PWM pulse width which is considered valid
 #define PULSE_MAX   (2250)      // maximum PWM pulse width which is considered valid

--- a/src/main.c
+++ b/src/main.c
@@ -186,7 +186,7 @@ int main(void)
     for (i = 0; i < RC_CHANS; i++)
         rcData[i] = 1502;
     rcReadRawFunc = pwmReadRawRC;
-    core.numRCChannels = MAX_INPUTS;
+    core.numRCChannels = MAX_PWM_INPUTS;
 
     if (feature(FEATURE_SERIALRX)) {
         switch (mcfg.serialrx_type) {
@@ -213,13 +213,17 @@ int main(void)
     // gpsInit will return if FEATURE_GPS is not enabled.
     gpsInit(mcfg.gps_baudrate);
 #endif
-#ifdef SONAR
-    // sonar stuff only works with PPM
+
     if (feature(FEATURE_PPM)) {
+        core.numRCChannels = MAX_PPM_INPUTS;
+#ifdef SONAR
+        // sonar stuff only works with PPM
         if (feature(FEATURE_SONAR))
             Sonar_init();
-    }
 #endif
+    }
+
+    core.numAuxChannels = constrain((mcfg.rc_channel_count - 4), 4, 8);
 
 #ifndef CJMCU
     if (feature(FEATURE_SOFTSERIAL)) {

--- a/src/mw.c
+++ b/src/mw.c
@@ -261,13 +261,13 @@ void computeRC(void)
     int i, chan;
 
     if (feature(FEATURE_SERIALRX)) {
-        for (chan = 0; chan < 8; chan++)
+        for (chan = 0; chan < mcfg.rc_channel_count; chan++)
             rcData[chan] = rcReadRawFunc(chan);
     } else {
-        static int16_t rcDataAverage[8][4];
+        static int16_t rcDataAverage[RC_CHANS][4];
         static int rcAverageIndex = 0;
 
-        for (chan = 0; chan < 8; chan++) {
+        for (chan = 0; chan < mcfg.rc_channel_count; chan++) {
             capture = rcReadRawFunc(chan);
 
             // validate input
@@ -478,7 +478,7 @@ void loop(void)
     static int16_t initialThrottleHold;
 #endif
     static uint32_t loopTime;
-    uint16_t auxState = 0;
+    uint32_t auxState = 0;
 #ifdef GPS
     static uint8_t GPSNavReset = 1;
 #endif
@@ -687,7 +687,8 @@ void loop(void)
         }
 
         // Check AUX switches
-        for (i = 0; i < 4; i++)
+
+        for (i = 0; i < core.numAuxChannels; i++)
             auxState |= (rcData[AUX1 + i] < 1300) << (3 * i) | (1300 < rcData[AUX1 + i] && rcData[AUX1 + i] < 1700) << (3 * i + 1) | (rcData[AUX1 + i] > 1700) << (3 * i + 2);
         for (i = 0; i < CHECKBOXITEMS; i++)
             rcOptions[i] = (auxState & cfg.activate[i]) > 0;

--- a/src/mw.h
+++ b/src/mw.h
@@ -246,7 +246,7 @@ typedef struct config_t {
     uint8_t acc_unarmedcal;                 // turn automatic acc compensation on/off
     uint8_t small_angle;                    // what is considered a safe angle for arming
 
-    uint16_t activate[CHECKBOXITEMS];       // activate switches
+    uint32_t activate[CHECKBOXITEMS];       // activate switches
 
     // Radio/ESC-related configuration
     uint8_t deadband;                       // introduce a deadband around the stick center for pitch and roll axis. Must be greater than zero.
@@ -352,7 +352,7 @@ typedef struct master_t {
     uint8_t power_adc_channel;              // which channel is used for current sensor. Right now, only 3 places are supported: RC_CH2 (unused when in CPPM mode, = 1), RC_CH8 (last channel in PWM mode, = 9), ADC_EXTERNAL_PAD (Rev5 only, = 5), 0 to disable
 
     // Radio/ESC-related configuration
-    uint8_t rcmap[8];                       // mapping of radio channels to internal RPYTA+ order
+    uint8_t rcmap[RC_CHANS];                // mapping of radio channels to internal RPYTA+ order
     uint8_t serialrx_type;                  // type of UART-based receiver (0 = spek 10, 1 = spek 11, 2 = sbus). Must be enabled by FEATURE_SERIALRX first.
     uint8_t spektrum_sat_bind;              // Spektrum satellite bind. 0 - 10 (0 = disabled)
     uint8_t spektrum_sat_on_flexport;       // Spektrum satellite on USART3 (flexport, available with rev5sp hardware)
@@ -367,6 +367,7 @@ typedef struct master_t {
     uint8_t rssi_adc_channel;               // Read analog-rssi from RC-filter (RSSI-PWM to RSSI-Analog), RC_CH2 (unused when in CPPM mode, = 1), RC_CH8 (last channel in PWM mode, = 9), ADC_EXTERNAL_PAD (Rev5 only, = 5), 0 to disable (disabled if rssi_aux_channel > 0 or rssi_adc_channel == power_adc_channel)
     uint16_t rssi_adc_max;                  // max input voltage defined by RC-filter (is RSSI never 100% reduce the value) (1...4095)
     uint16_t rssi_adc_offset;               // input offset defined by RC-filter (0...4095)
+    uint8_t rc_channel_count;               // total number of incoming RC channels that should be processed, range (8...18), default is 8
 
     // gps-related stuff
     uint8_t gps_type;                       // See GPSHardware enum.
@@ -400,6 +401,7 @@ typedef struct core_t {
     serialPort_t *telemport;
     serialPort_t *rcvrport;
     uint8_t numRCChannels;                  // number of rc channels as reported by current input driver
+    uint8_t numAuxChannels;
     bool useServo;                          // feature SERVO_TILT or wing/airplane mixers will enable this
     uint8_t numServos;                      // how many total hardware servos we have. used by mixer
 } core_t;

--- a/src/serial.c
+++ b/src/serial.c
@@ -83,6 +83,7 @@
 #define MSP_BUILDINFO            69     //out message         build date as well as some space for future expansion
 
 #define INBUF_SIZE 128
+#define MAX_SERIAL_INPUTS 8
 
 typedef struct box_t {
     const uint8_t boxIndex;         // this is from boxnames enum
@@ -833,13 +834,13 @@ static void evaluateCommand(void)
             break;
 
         case MSP_RCMAP:
-            headSerialReply(MAX_INPUTS); // TODO fix this
-            for (i = 0; i < MAX_INPUTS; i++)
+            headSerialReply(MAX_SERIAL_INPUTS); // TODO fix this
+            for (i = 0; i < MAX_SERIAL_INPUTS; i++)
                 serialize8(mcfg.rcmap[i]);
             break;
         case MSP_SET_RCMAP:
             headSerialReply(0);
-            for (i = 0; i < MAX_INPUTS; i++)
+            for (i = 0; i < MAX_SERIAL_INPUTS; i++)
                 mcfg.rcmap[i] = read8();
             break;
 


### PR DESCRIPTION
added two new CLI var's for controlling the number of RC & AUX channels that are processed by the RC-handling code routines, 'rc_channel_count' and 'rc_aux_count'. 

'rc_channel_count' sets the number of channels that are processed by the RC handling code & stored in the raw RC channel data array (based on the internal channel mapping scheme).  range is (8...18), default is '8'.

'rc_aux_count' sets the number of channels that are processed by the AUX-handling code for dealing with flight mode switches. range is (4...8), default is '4'. NOTE: this must be set in accordance with 'rc_channel_count' value. Obviously, flight mode settings for any AUX channel '5&above' would need to be configured manually via the CLI, seeing as configurator only supports 4 AUX channels.

* nothing will break if these values are ignored, as the defaults will maintain the existing behavior. It gives the user the ability to increase the amount of raw RC channels that can be accessed & utilized within BF. Tested & verified to work with 16CH PPM. Code would need to be adjusted & tested tested for the serial RC interfaces.

'rssi_aux_channel' range was expanded to allow for selection for a high AUX channel number, yet keeping it <= the 18 channel maximum.